### PR TITLE
fix: local config template missing variable

### DIFF
--- a/bugsink/conf_templates/local.py.template
+++ b/bugsink/conf_templates/local.py.template
@@ -49,6 +49,13 @@ EMAIL_BACKEND = "bugsink.email_backends.QuietConsoleEmailBackend"
 # EMAIL_USE_TLS = ...
 # SERVER_EMAIL = DEFAULT_FROM_EMAIL = "Bugsink <bugsink@example.org>"
 
+# constants for "create by" (user/team/project) settings
+CB_ANYBODY = "CB_ANYBODY"
+CB_MEMBERS = "CB_MEMBERS"
+CB_ADMINS = "CB_ADMINS"
+CB_NOBODY = "CB_NOBODY"
+
+
 BUGSINK = {
     # The URL where the Bugsink instance is hosted. This is used in the email notifications and to construct DSNs.
     "BASE_URL": "http://{{ host }}:{{ port }}",  # no trailing slash


### PR DESCRIPTION
## Background

Local template using constant `CB_NOBODY` but not define yet.
docker template and singleserver template have this

## Solution

Add same define for local template
