### PR TITLE
Apply source mapping when sourcemap contains multiple sources

### DIFF
--- a/files/tests.py
+++ b/files/tests.py
@@ -126,7 +126,7 @@ class FilesTests(TransactionTestCase):
                     200, response.status_code, response.content if response.status_code != 302 else response.url)
 
                 # we could/should make this more general later; this is great for example nr.1:
-                key_phrase = '<span class="font-bold">captureException</span> line <span class="font-bold">15</span>'
+                key_phrase = '<span class="font-bold">captureException.js</span> line <span class="font-bold">7</span>'
                 self.assertTrue(key_phrase in response.content.decode('utf-8'))
 
             except Exception as e:


### PR DESCRIPTION
The assumption does not generally hold :-)

sourcemaps can contain many files bundled into one; debugId helps with tagging that sourcemap. 

This reads all content into the dictionary and uses the sourcemap lookup token to determine which actual file it was. It also patches the filename and function, although I am not sure that is actually the function.