### PR TITLE
Upgrade to Django 5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn==23.0.*
-Django==4.2.*
+Django==5.2.*
 sentry-sdk==2.27.*
 django-tailwind==3.6.*
 jsonschema==4.23.*


### PR DESCRIPTION
'shooting in the dark' edition, i.e. just upgrading the version number without RTFM and seeing if the CI still runs