### PR TITLE
vacuum_eventless_issuetags command

### DIFF
--- a/tags/management/commands/vacuum_eventless_issuetags.py
+++ b/tags/management/commands/vacuum_eventless_issuetags.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from tags.tasks import vacuum_eventless_issuetags
+
+
+class Command(BaseCommand):
+    help = "Kick off tag cleanup by vacuuming IssueTag objects for which there is no EventTag equivalent"
+
+    def handle(self, *args, **options):
+        vacuum_eventless_issuetags.delay()
+        self.stdout.write("Started tag vacuum via task queue.")

--- a/tags/models.py
+++ b/tags/models.py
@@ -52,6 +52,9 @@ class TagKey(models.Model):
         # the obvious constraint, which doubles as a lookup index for store_tags and search.
         unique_together = ('project', 'key')
 
+    def __str__(self):
+        return f"{self.key}"
+
 
 class TagValue(models.Model):
     project = models.ForeignKey(Project, blank=False, null=False, on_delete=models.DO_NOTHING)

--- a/tags/models.py
+++ b/tags/models.py
@@ -74,7 +74,7 @@ class EventTag(models.Model):
     # value already implies key in our current setup.
     value = models.ForeignKey(TagValue, blank=False, null=False, on_delete=models.DO_NOTHING)
 
-    # issue is a denormalization that allows for a single-table-index for efficient search.
+    # issue is a denormalization that allows for a single-table-index for efficient search/vacuum_eventless_issuetags.
     issue = models.ForeignKey(
         'issues.Issue', blank=False, null=False, on_delete=models.DO_NOTHING, related_name="event_tags")
 
@@ -97,6 +97,7 @@ class EventTag(models.Model):
             # for search, which filters a list of EventTag down to those matching certain values and a given issue.
             # (both orderings of the (value, issue) would work for the current search query; if we ever introduce
             # "search across issues" the below would work for that too (but the reverse wouldn't))
+            # also used by vacuum_eventless_issuetags (ORed Q(issue_id, value_id))
             models.Index(fields=['value', 'issue', 'digest_order']),
         ]
 

--- a/tags/tasks.py
+++ b/tags/tasks.py
@@ -1,7 +1,10 @@
+from django.db.models import Q
+
 from snappea.decorators import shared_task
 
+from bugsink.moreiterutils import batched
 from bugsink.transaction import immediate_atomic, delay_on_commit
-from tags.models import TagValue, TagKey, EventTag, IssueTag
+from tags.models import TagValue, TagKey, EventTag, IssueTag, _or_join
 
 BATCH_SIZE = 10_000
 
@@ -82,3 +85,63 @@ def vacuum_tagkeys(min_id=0):
 
     # Defer next batch
     vacuum_tagkeys.delay(ids_to_check[-1])
+
+
+@shared_task
+def vacuum_eventless_issuetags(min_id=0):
+    # This task removes IssueTag entries that are no longer referenced by any EventTag for an Event on the same Issue.
+    #
+    # Under normal operation, we evict Events and their EventTags. However, we do not track how many EventTags back
+    # an IssueTag, so we have historically chosen not to clean up IssueTags during Event deletion. (see #134)
+    #
+    # This has the upside of being cheap and preserving all known values for an Issue (e.g. all environments/releases
+    # ever seen). But it comes with downsides:
+    #
+    # * stale IssueTags remain for deleted Events
+    # * search-by-tag may return Issues without matching Events
+    # * TagValues will not be vacuumed as long as they’re still referenced by an IssueTag
+    #
+    # This task aims to reconcile that, in a delayed and resumable fashion.
+
+    BATCH_SIZE = 512  # close to 500, and a multiple of 64
+
+    # Community wisdom (says ChatGPT, w/o source): queries with dozens of OR clauses can slow down significantly. 64 is
+    # a safe, batch size that avoids planner overhead and keeps things fast across databases.
+    INNER_BATCH_SIZE = 64
+
+    with immediate_atomic():
+        issue_tag_infos = list(
+            IssueTag.objects
+            .filter(id__gt=min_id)
+            .order_by('id')
+            .values('id', 'issue_id', 'value_id')[:BATCH_SIZE]
+        )
+
+        for issue_tag_infos_batch in batched(issue_tag_infos, INNER_BATCH_SIZE):
+            matching_eventtags = _or_join([
+                Q(issue_id=it['issue_id'], value_id=it['value_id']) for it in issue_tag_infos_batch
+            ])
+
+            if matching_eventtags:
+                in_use_issue_value_pairs = set(
+                    EventTag.objects
+                    .filter(matching_eventtags)
+                    .values_list('issue_id', 'value_id')
+                )
+            else:
+                in_use_issue_value_pairs = set()
+
+            stale_issuetag_ids = [
+                it['id']
+                for it in issue_tag_infos_batch
+                if (it['issue_id'], it['value_id']) not in in_use_issue_value_pairs
+            ]
+
+            if stale_issuetag_ids:
+                IssueTag.objects.filter(id__in=stale_issuetag_ids).delete()
+
+    # We don't have a continuation for the "done" case. One could argue: kick off vacuum_tagvalues there, but I'd rather
+    # rather build the toolbox of cleanup tasks first and see how they might fit together later. Because the downside of
+    # triggering the next vacuum command would be that "more things might happen too soon".
+
+    vacuum_eventless_issuetags.delay(issue_tag_infos[-1]['id'])

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -129,6 +129,13 @@ class StoreTagsTestCase(DjangoTestCase):
         self.assertEqual(IssueTag.objects.count(), 2)
         self.assertEqual(2, IssueTag.objects.filter(value__key__key="foo").count())
 
+    def test_store_many_tags(self):
+        # observed: a non-batched implementation of store_tags() would crash (e.g. in sqlite: Expression tree is too
+        # large (maximum depth 1000)); if the below doesn't crash, we've got a batched implementation that works
+        event = create_event(self.project, issue=self.issue)
+        store_tags(event, self.issue, {f"key-{i}": f"value-{i}" for i in range(512)})
+        self.assertEqual(IssueTag.objects.filter(issue=self.issue).count(), 512)
+
 
 class SearchParserTestCase(RegularTestCase):
 

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -119,6 +119,16 @@ class StoreTagsTestCase(DjangoTestCase):
         self.assertEqual(self.issue.tags.first().count, 2)
         self.assertEqual(self.issue.tags.first().value.key.key, "foo")
 
+    def test_store_same_tag_on_two_issues_creates_two_issuetags(self):
+        store_tags(self.event, self.issue, {"foo": "bar"})
+
+        other_issue, _ = get_or_create_issue(self.project, event_data=create_event_data("other_issue"))
+        other_event = create_event(self.project, issue=other_issue)
+        store_tags(other_event, other_issue, {"foo": "bar"})
+
+        self.assertEqual(IssueTag.objects.count(), 2)
+        self.assertEqual(2, IssueTag.objects.filter(value__key__key="foo").count())
+
 
 class SearchParserTestCase(RegularTestCase):
 


### PR DESCRIPTION
See #134 

In the light of the discussion on #134, this implements the "clean up later"
solution: a vacuum task that deletes IssueTags no longer referenced by any
EventTag on the same Issue.

This doesn't prevent stale IssueTags from being created but ensures they are
eventually removed, enabling follow-up cleanup (e.g. of TagValues).

Performance-wise, this is a relatively safe path forward; it can run off-hours
or not at all, depending on preferences. Semantically it's the least clear:
whether an Issue appears to be tagged may now depend on whether vacuum has run.