### PR TITLE
Auto-clean binlogs on docker compose for mysql

### DIFF
--- a/compose-sample.yaml
+++ b/compose-sample.yaml
@@ -2,6 +2,8 @@ services:
   mysql:
     image: mysql:latest
     restart: unless-stopped
+    command : "--binlog_expire_logs_seconds=3600"
+
     environment:
       MYSQL_ROOT_PASSWORD: change_your_passwords_for_real_usage # TODO: Change this
       MYSQL_DATABASE: bugsink


### PR DESCRIPTION
- [ ] If I use the sample docker compose file for mysql, I end up with a total 5G database of bugsink taking around 350G on disk due to high event volume. This is due to a long tail of binlog files being created.
- [ ] Adding this one change allows me to auto-prune that tail and set an aggressive value like 600 seconds for bugsink instances which face a high volume of events (even though they are being cleaned by the event limit in bugsink)

NOTE: I was not able to find how to update the docs at this link so i left it out of my PR. https://www.bugsink.com/docs/mysql/