### PR TITLE
Non-root docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 # Git is needed by setuptools_scm to get the version from the git tag
 RUN apt update && apt install -y git
 RUN pip install -e .
+RUN groupadd -r bugsink && useradd  -r -g bugsink bugsink
+
+USER bugsink
 
 RUN ["bugsink-manage", "migrate", "snappea", "--database=snappea"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 RUN apt update && apt install -y git
 RUN pip install -e .
 
-RUN groupadd -r bugsink \
- && useradd  -r -g bugsink bugsink \
+RUN groupadd --gid 14237 bugsink \
+ && useradd --uid 14237 --gid bugsink \
  && mkdir -p /data \
  && chown -R bugsink:bugsink /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,11 @@ COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 # Git is needed by setuptools_scm to get the version from the git tag
 RUN apt update && apt install -y git
 RUN pip install -e .
-RUN groupadd -r bugsink && useradd  -r -g bugsink bugsink
+
+RUN groupadd -r bugsink \
+ && useradd  -r -g bugsink bugsink \
+ && mkdir -p /data \
+ && chown -R bugsink:bugsink /data
 
 USER bugsink
 

--- a/Dockerfile.fromwheel
+++ b/Dockerfile.fromwheel
@@ -73,8 +73,8 @@ RUN --mount=type=cache,target=/var/cache/buildkit/pip \
 COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 COPY gunicorn.docker.conf.py /app/
 
-RUN groupadd -r bugsink \
- && useradd  -r -g bugsink bugsink \
+RUN groupadd --gid 14237 bugsink \
+ && useradd --uid 14237 --gid bugsink \
  && mkdir -p /data \
  && chown -R bugsink:bugsink /data
 

--- a/Dockerfile.fromwheel
+++ b/Dockerfile.fromwheel
@@ -73,7 +73,11 @@ RUN --mount=type=cache,target=/var/cache/buildkit/pip \
 COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 COPY gunicorn.docker.conf.py /app/
 
-RUN groupadd -r bugsink && useradd  -r -g bugsink bugsink
+RUN groupadd -r bugsink \
+ && useradd  -r -g bugsink bugsink \
+ && mkdir -p /data \
+ && chown -R bugsink:bugsink /data
+
 USER bugsink
 
 RUN ["bugsink-manage", "migrate", "snappea", "--database=snappea"]

--- a/Dockerfile.fromwheel
+++ b/Dockerfile.fromwheel
@@ -73,6 +73,9 @@ RUN --mount=type=cache,target=/var/cache/buildkit/pip \
 COPY bugsink/conf_templates/docker.py.template bugsink_conf.py
 COPY gunicorn.docker.conf.py /app/
 
+RUN groupadd -r bugsink && useradd  -r -g bugsink bugsink
+USER bugsink
+
 RUN ["bugsink-manage", "migrate", "snappea", "--database=snappea"]
 
 HEALTHCHECK CMD python -c 'import requests; requests.get("http://localhost:8000/health/ready").raise_for_status()'

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -103,10 +103,6 @@ else:
     # which allows for throwaway setups (no volume mounted) to work out of the box.
     DATABASES['default']['NAME'] = os.getenv("DATABASE_PATH", '/data/db.sqlite3')
     database_path = os.path.dirname(DATABASES['default']['NAME'])
-    if not os.path.exists(database_path):
-        print(f"WARNING: {database_path} dir does not exist; creating it.")
-        print("WARNING: data will be lost when the container is removed.")
-        os.makedirs(database_path)
 
 
 if os.getenv("EMAIL_HOST"):

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -67,6 +67,9 @@ SNAPPEA = {
 
 }
 
+# Not actually a "database", this is a (tmp to the container) message queue.
+DATABASES["snappea"]["NAME"] = '/tmp/snappea.sqlite3'
+
 
 if os.getenv("DATABASE_URL"):
     DATABASE_URL = os.getenv("DATABASE_URL")


### PR DESCRIPTION
draft to keep track of progress while we think about / discuss the implications of this:

> `data/db.sqlite3` (and `/data/` itself) is the biggest remaining question. First: we have ad-hoc creation of the dir (and the db) now if so-needed (when sqlite is configured). But that won't work in the future, because `/` is root-owned, and the creation of `/data` will be by `appuser`. I can imagine solutions in the Dockerfile (just create as root, assign the appuser), but I'm not sure how those solutions will affect installations that already have a more sophisticated setup for `/data/` (i.e. a mounted volume through one of the various mechanisms for that, and across container technologies).