### PR TITLE
PID_FILE default to None and use b108_makedirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## ..... (unreleased)
+
+### Backwards incompatible changes
+
+Fail to start when `PID_FILE` is configured to be in a directory not owned by the process running gunicorn/snappea
+(typically: the `bugsink` user). The reason for this is: extra defense in depth, as per #174.
+
+Ensure that `PID_FILE` is either `None` (recommended in systemd setups, i.e. recommended in the recommended case) or, if
+you must, in file in a directory "one level deep" (e.g. `/tmp/snappea/snappea.pid` or `{base_path}/snappea/snappea.pid`)
+
+Otherwise you'll get a B108SecurityError ("Target path owned by uid other than me: ...")
+
+See #195, #196
+
 ## 2.3.1 (30 June 2026)
 
 * Decode percent-encoded components from `DATABASE_URL` after parsing (See #423)

--- a/bugsink/settings/development.py
+++ b/bugsink/settings/development.py
@@ -69,7 +69,8 @@ SNAPPEA = {
     "TASK_ALWAYS_EAGER": True,  # at least for (unit) tests, this is a requirement
     "NUM_WORKERS": 1,
 
-    # no_bandit_expl: development setting, we know that this is insecure "in theory" at least
+    # development.py is precisly the intended use for a non-None PID_FILE: no systemd/Docker, i.e. no process manager
+    # no_bandit_expl: usage locations use b108_makedirs;
     "PID_FILE": "/tmp/bugsink/snappea.pid",  # nosec B108
 }
 

--- a/snappea/foreman.py
+++ b/snappea/foreman.py
@@ -145,8 +145,7 @@ class Foreman:
             # as per the above: not bullet proof, and non-critical, hence also: not a reason to crash on this.
             logger.error("Startup: Ignored Error while checking PID file", exc_info=e)
 
-        # Note: no b108_makedirs here yet, because we can't assume a self-owned containing directory (see #195)
-        os.makedirs(os.path.dirname(self.settings.PID_FILE), exist_ok=True)
+        b108_makedirs(os.path.dirname(self.settings.PID_FILE))
         with open(self.settings.PID_FILE, "w") as f:
             f.write(str(pid))
 

--- a/snappea/settings.py
+++ b/snappea/settings.py
@@ -4,8 +4,7 @@ from django.conf import settings
 DEFAULTS = {
     "TASK_ALWAYS_EAGER": False,
 
-    # no_bandit_expl: monitored in #195
-    "PID_FILE": "/tmp/bugsink/snappea.pid",  # nosec
+    "PID_FILE": None,
 
     # no_bandit_expl: the usage of this path (in the foreman) is protected with `b108_makedirs`
     "WAKEUP_CALLS_DIR": "/tmp/snappea.wakeup",  # nosec


### PR DESCRIPTION
Harden Snappea `PID_FILE` directory creation by using `b108_makedirs`, matching the temporary-directory hardening already used for other Snappea paths.

This means a configured PID file must live in a directory owned by the process user.

- Use `b108_makedirs()` before writing `PID_FILE`.
- Default Snappea `PID_FILE` to `None`, closing the small remaining gap from #99 for configs that omit `PID_FILE` entirely.
- Keep development explicitly configured with a non-`None` PID file, since development is the intended non-systemd/non-Docker case.
- Add a backwards-incompatible changelog note for older copied configs that still point at an unsuitable PID-file directory.

This work had been postponed for a long while in the (given the analysis done in the commits overly cautious) idea of giving outdated installations time to catch up.

See #99, #195, #196.