### PR TITLE
DRAFT (October 2026): Drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         db: [sqlite, mysql, postgres]
         include:
           - db: mysql

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Self-hosted Error Tracking"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Python 3.10 has now reached its own EOL. Looking at popular Linux distros and their Python versions (which matter more in practice than the PSF’s dates):

Not affected:

* Ubuntu 24.04 LTS (EOL Apr 2029) has Python 3.12
* Debian 12 Bookworm (EOL Jun 2028) has Python 3.11
* Debian 13 Trixie (EOL Jun 2030) has Python 3.13
* RHEL 9 (EOL May 2032) defaults to 3.9 but also offers 3.11 and 3.12
* RHEL 10 (EOL May 2035) has Python 3.12
* The Docker image we use has Python version configurable

Affected:

* Ubuntu 22.04 LTS (EOL Apr 2027) has Python 3.10

Given Bugsink’s own age, this isn’t really a concern: the first single-server installation instructions appeared in October 2024, and they mentioned Ubuntu 24.04 specifically as the deployment target, which makes it less likely 22.04 is used in practice. In addition Ubuntu 22.04 only has about 6 months of standard support left at this point