### PR TITLE
Improve Slack alerts to work with Mattermost.

### DIFF
--- a/alerts/service_backends/slack.py
+++ b/alerts/service_backends/slack.py
@@ -94,14 +94,14 @@ def slack_backend_send_test_message(webhook_url, project_name, display_name, ser
                     "text": {
                         "type": "plain_text",
                         "text": "TEST issue",
-                    }
+                    },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": "Test message by Bugsink to test the webhook setup.",
-                    }
+                    },
                 },
                 {
                     "type": "section",
@@ -113,7 +113,7 @@ def slack_backend_send_test_message(webhook_url, project_name, display_name, ser
                         {
                             "type": "mrkdwn",
                             "text": "*message backend*: " + _safe_markdown(display_name),
-                        }
+                        },
                     ]
                 }
             ]}
@@ -152,15 +152,15 @@ def slack_backend_send_alert(
                     "text": {
                         "type": "plain_text",
                         "text": f"{alert_reason} issue",
-                    }
+                    },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": link,
-                    }
-                }
+                    },
+                },
                ]
 
     if unmute_reason:
@@ -169,7 +169,7 @@ def slack_backend_send_alert(
             "text": {
                 "type": "mrkdwn",
                 "text": unmute_reason,
-            }
+            },
         })
 
     # assumption: visavis email, project.name is of less importance, because in slack-like things you may (though not
@@ -185,7 +185,7 @@ def slack_backend_send_alert(
     # if event.environment:
     #     fields["environment"] = event.environment
 
-    data = {"text": f"{alert_reason} issue",
+    data = {"text" : sections[0]["text"]["text"],  # mattermost requires at least one text field; use the first section
             "blocks": sections + [
                 {
                     "type": "section",
@@ -195,7 +195,7 @@ def slack_backend_send_alert(
                             "text": f"*{field}*: " + _safe_markdown(value),
                         } for field, value in fields.items()
                     ]
-                }
+                },
             ]}
 
     try:

--- a/alerts/service_backends/slack.py
+++ b/alerts/service_backends/slack.py
@@ -87,7 +87,7 @@ def _store_success_info(service_config_id):
 def slack_backend_send_test_message(webhook_url, project_name, display_name, service_config_id):
     # See Slack's Block Kit Builder
 
-    data = {"text": "Test message by Bugsink to test the webhook setup.", 
+    data = {"text": "Test message by Bugsink to test the webhook setup.",
             "blocks": [
                 {
                     "type": "header",
@@ -185,7 +185,7 @@ def slack_backend_send_alert(
     # if event.environment:
     #     fields["environment"] = event.environment
 
-    data = {"text" : sections[0]["text"]["text"],  # mattermost requires at least one text field; use the first section
+    data = {"text": sections[0]["text"]["text"],  # mattermost requires at least one text field; use the first section
             "blocks": sections + [
                 {
                     "type": "section",

--- a/alerts/service_backends/slack.py
+++ b/alerts/service_backends/slack.py
@@ -87,20 +87,21 @@ def _store_success_info(service_config_id):
 def slack_backend_send_test_message(webhook_url, project_name, display_name, service_config_id):
     # See Slack's Block Kit Builder
 
-    data = {"blocks": [
+    data = {"text": "Test message by Bugsink to test the webhook setup.", 
+            "blocks": [
                 {
                     "type": "header",
                     "text": {
                         "type": "plain_text",
                         "text": "TEST issue",
-                    },
+                    }
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": "Test message by Bugsink to test the webhook setup.",
-                    },
+                    }
                 },
                 {
                     "type": "section",
@@ -112,10 +113,9 @@ def slack_backend_send_test_message(webhook_url, project_name, display_name, ser
                         {
                             "type": "mrkdwn",
                             "text": "*message backend*: " + _safe_markdown(display_name),
-                        },
+                        }
                     ]
                 }
-
             ]}
 
     try:
@@ -152,15 +152,15 @@ def slack_backend_send_alert(
                     "text": {
                         "type": "plain_text",
                         "text": f"{alert_reason} issue",
-                    },
+                    }
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": link,
-                    },
-                },
+                    }
+                }
                ]
 
     if unmute_reason:
@@ -169,7 +169,7 @@ def slack_backend_send_alert(
             "text": {
                 "type": "mrkdwn",
                 "text": unmute_reason,
-            },
+            }
         })
 
     # assumption: visavis email, project.name is of less importance, because in slack-like things you may (though not
@@ -185,7 +185,8 @@ def slack_backend_send_alert(
     # if event.environment:
     #     fields["environment"] = event.environment
 
-    data = {"blocks": sections + [
+    data = {"text": f"{alert_reason} issue",
+            "blocks": sections + [
                 {
                     "type": "section",
                     "fields": [
@@ -194,7 +195,7 @@ def slack_backend_send_alert(
                             "text": f"*{field}*: " + _safe_markdown(value),
                         } for field, value in fields.items()
                     ]
-                },
+                }
             ]}
 
     try:


### PR DESCRIPTION
Mattermost is an open source alternative to Slack. It's supposed to be compatible with Slack's Incoming Webhook format as well. However, the Slack alert messages produced by Bugsink do not work with Mattermost due to differences in the JSON parsing:

- Mattermost is disturbed by trailing commas 
- Bugsink's alerts consist of an array of `blocks`  -- Mattermost insists on receiving at least a `text` key on the root level of the payload.

While it was certainly possible to create a distinct Mattermost alerts implementation in Bugsink, I'd propose to modify the Slack alerts feature in this case to achieve broader compatibility with Slack and services striving to be compatible.