### PR TITLE
Migrate docker compose example to alpine postgres

### DIFF
--- a/docker-compose-sample.yaml
+++ b/docker-compose-sample.yaml
@@ -1,24 +1,24 @@
 services:
-  mysql:
-    image: mysql:latest
+  db:
+    image: postgres:17-alpine
     restart: unless-stopped
-    command : "--binlog_expire_logs_seconds=3600"
-
     environment:
-      MYSQL_ROOT_PASSWORD: change_your_passwords_for_real_usage # TODO: Change this
-      MYSQL_DATABASE: bugsink
+      POSTGRES_USER: bugsinkuser 
+      POSTGRES_PASSWORD: your_super_secret_password  # Change this
+      POSTGRES_DB: bugsink
     volumes:
-      - my-datavolume:/var/lib/mysql
+      - db-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "exit | mysql -h localhost -P 3306 -u root -p$$MYSQL_ROOT_PASSWORD" ]  # 'exit |' closes the MySQL input prompt
-      interval: 1s
-      timeout: 20s
-      retries: 30
+      test: pg_isready -h db      
+      retries: 5
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
 
   web:
     image: bugsink/bugsink
     depends_on:
-      mysql:
+      db:
         condition: service_healthy
     restart: unless-stopped
     ports:
@@ -27,7 +27,7 @@ services:
       SECRET_KEY: django-insecure-RMLYThim9NybWgXiUGat32Aa0Qbgqscf4NPDQuZO2glcZPOiXn  # Change this (and remove django-insecure prefix), e.g. openssl rand -base64 50
       CREATE_SUPERUSER: admin:admin  # Change this (or remove it and execute 'createsuperuser' against the running container)
       PORT: 8000
-      DATABASE_URL: mysql://root:change_your_passwords_for_real_usage@mysql:3306/bugsink
+      DATABASE_URL: postgresql://bugsinkuser:your_super_secret_password@db:5432/bugsink # Change password to match POSTGRES_PASSWORD above
       BEHIND_HTTPS_PROXY: "false"  # Change this for setups behind a proxy w/ ssl enabled
       BASE_URL: "http://localhost:8000"
     healthcheck:
@@ -37,4 +37,4 @@ services:
       retries: 10
 
 volumes:
-  my-datavolume:
+  db-data:


### PR DESCRIPTION
This PR proposes to migrate the docker compose example setup from mysql to an alpine-postgres image.
The mysql compose setup uses around 450mb memory right after the initial pull. The alpine postgres image uses around 30mb memory after the initial pull.

This PR is mighty opinionated, but I feel like that the docker compose sample will be used mainly by hobbyists and people who quickly want to check out bugsink. For many self-hosters, memory is the limiting factor on their setup. And pulling smaller images is also just faster than bigger ones.

mysql memory usage after initial pull:
<img width="1984" height="1152" alt="CleanShot 2025-09-13 at 18 34 44@2x" src="https://github.com/user-attachments/assets/447f6995-a0ab-4440-8791-ed13da72d259" />


alpine postgres memory usage after initial pull:
<img width="974" height="600" alt="image" src="https://github.com/user-attachments/assets/d19191da-162d-4744-8b0a-92520ea25f14" />

## TODO
- [ ] Update docs to mention postgres instead of mysql https://www.bugsink.com/docs/docker-compose-install/ 

<img width="2480" height="1258" alt="CleanShot 2025-09-13 at 18 39 15@2x" src="https://github.com/user-attachments/assets/a3627ce5-cc0c-4b63-8c52-203acd27723c" />