### PR TITLE
Fix exception title being cut off

### DIFF
--- a/issues/templates/issues/stacktrace.html
+++ b/issues/templates/issues/stacktrace.html
@@ -29,7 +29,7 @@
 
 {% for exception in exceptions %}
 
-    <div class="flex items-start flex-col-reverse lg:flex-row">
+    <div class="flex items-start flex-col-reverse gap-2">
         <div class="overflow-hidden">
             {% if forloop.counter0 == 0 %}
             <div class="italic text-ellipsis whitespace-nowrap overflow-hidden">{{ event.ingested_at|date:"j M G:i T" }} (Event {{ event.digest_order|intcomma }} of {{ issue.digested_event_count|intcomma }} total{% if q %} — {{ event_qs_count|intcomma }} found by search{% endif %})</div>
@@ -39,7 +39,7 @@
 
         </div>
         {% if forloop.counter0 == 0 %}
-        <div class="ml-auto flex flex-none flex-col-reverse 3xl:flex-row"> {# container of 2 divs: one for buttons, one for event-nav; on smaller screens these are 2 rows; on bigger they are side-by-side  #}
+        <div class="flex flex-none flex-col-reverse 3xl:flex-row"> {# container of 2 divs: one for buttons, one for event-nav; on smaller screens these are 2 rows; on bigger they are side-by-side  #}
             <div class="flex place-content-end self-stretch pt-2 3xl:pt-0 {# <= to keep the buttons apart #} pb-4 lg:pb-0 {# <= to keep the buttons & h1-block apart #}">
                 <button class="font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-1 pt-1 mr-2 border-2 rounded-md hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3" onclick="showAllFrames()">Show all</button>
                 <button class="font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-1 pt-1 mr-2 border-2 rounded-md hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3" onclick="showInAppFrames()">Show in-app</button>


### PR DESCRIPTION
The exception title gets cut off by the buttons, making it so very little gets displayed:

<img width="1391" height="178" alt="image" src="https://github.com/user-attachments/assets/46400c1d-5ab5-4c13-bf51-d55379cf5aea" />

This PR fixes this so the whole line is taken:

<img width="1069" height="229" alt="image" src="https://github.com/user-attachments/assets/9dd49268-2c94-4850-8dbc-11c206b5aa93" />

Alternatively, the HTML could be modified to put the title below the buttons, but keep the time + exception type to the left of the buttons.