### PR TITLE
Fix background of event search inputs in dark mode

### DIFF
--- a/issues/templates/issues/_event_nav.html
+++ b/issues/templates/issues/_event_nav.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
                 <form action="{% url this_view issue_pk=issue.pk nav="last" %}" method="get">{# nav="last": when doing a new search on an event-page, you want the most recent matching event to show up #}
-                <input type="text" name="q" value="{{ q }}" placeholder="{% translate 'search...' %}" class="focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700 rounded-md mr-2"/>
+                <input type="text" name="q" value="{{ q }}" placeholder="{% translate 'search...' %}" class="bg-slate-50 dark:bg-slate-800 focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700  rounded-md mr-2"/>
                 </form>
 
                 {% if has_prev %} {# no need for 'is_first': if you can go to the left, you can go all the way to the left too #}

--- a/issues/templates/issues/event_404.html
+++ b/issues/templates/issues/event_404.html
@@ -16,7 +16,7 @@
         <div class="flex place-content-end">
             {# copy/paste of _event_nav, but not based on any event (we have none), prev/next are meaningless also; first/last only when we have an event_qs to navigate through #}
                 <form action="{% url this_view issue_pk=issue.pk nav="last" %}" method="get">{# nav="last": when doing a new search on an event-page, you want the most recent matching event to show up #}
-                <input type="text" name="q" value="{{ q }}" placeholder="search..." class="focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700 rounded-md mr-2"/>
+                <input type="text" name="q" value="{{ q }}" placeholder="search..." class="bg-slate-50 dark:bg-slate-800 focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700 rounded-md mr-2"/>
                 </form>
 
                 {% if event_qs_count %}

--- a/issues/templates/issues/event_list.html
+++ b/issues/templates/issues/event_list.html
@@ -27,7 +27,7 @@
         {# adapted copy/pasta from _event_nav #}
         <div class="flex place-content-end">
                 <form action="." method="get">
-                <input type="text" name="q" value="{{ q }}" placeholder="search..." class="focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700 rounded-md mr-2"/>
+                <input type="text" name="q" value="{{ q }}" placeholder="search..." class="bg-slate-50 dark:bg-slate-800 focus:border-cyan-500 dark:focus:border-cyan-400 focus:ring-cyan-200 dark:focus:ring-cyan-700  rounded-md mr-2"/>
                 </form>
 
                 {% if page_obj.has_previous %} {# no need for 'is_first': if you can go to the left, you can go all the way to the left too #}


### PR DESCRIPTION
Fixed issue when input for search field in events had wrong background color in dark mode.

Before:
<img width="528" height="108" alt="Screenshot 2026-01-09 at 12 23 26" src="https://github.com/user-attachments/assets/a687681a-75f6-4005-a4bf-cd300dba831c" />

After:
<img width="517" height="105" alt="Screenshot 2026-01-09 at 12 23 40" src="https://github.com/user-attachments/assets/c8563c78-4755-40ad-95a7-3ed489db8096" />
