### PR TITLE
Add a single synchronous vacuum command

### DIFF
--- a/bsmain/management/commands/vacuum.py
+++ b/bsmain/management/commands/vacuum.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+
+from files.tasks import vacuum_files_sync
+from tags.tasks import vacuum_eventless_issuetags_sync, vacuum_tags_sync
+
+
+class Command(BaseCommand):
+    help = "Vacuum old/stale data. Single point of entry for all vacuum_* tasks. Runs 'sync' (waits for completion)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--files',
+            action='store_true',
+            help="Run old file and chunk cleanup.",
+        )
+        parser.add_argument(
+            '--tags',
+            action='store_true',
+            help="Run orphaned TagValue and TagKey cleanup.",
+        )
+        parser.add_argument(
+            '--eventless-issuetags',
+            action='store_true',
+            help="Run IssueTag cleanup for rows without matching EventTag rows.",
+        )
+        parser.add_argument(
+            '--chunk-max-days',
+            type=int,
+            default=1,
+            help="Delete Chunk objects older than this many days (default: 1).",
+        )
+        parser.add_argument(
+            '--file-max-days',
+            type=int,
+            default=90,
+            help="Delete File objects not accessed for more than this many days (default: 90).",
+        )
+
+    def handle(self, *args, **options):
+        run_files = options['files']
+        run_tags = options['tags']
+        run_eventless_issuetags = options['eventless_issuetags']
+
+        if not any([run_files, run_tags, run_eventless_issuetags]):
+            # If no specific options were provided, run all vacuum tasks by default.
+            run_files = True
+            run_tags = True
+            run_eventless_issuetags = True
+
+        if run_files:
+            self.stdout.write("Vacuuming files...")
+            vacuum_files_sync(
+                chunk_max_days=options['chunk_max_days'],
+                file_max_days=options['file_max_days'],
+            )
+
+        if run_eventless_issuetags:
+            self.stdout.write("Vacuuming eventless issuetags...")
+            vacuum_eventless_issuetags_sync()
+
+        if run_tags:
+            self.stdout.write("Vacuuming tags...")
+            vacuum_tags_sync()
+
+        self.stdout.write(self.style.SUCCESS("Vacuum complete."))

--- a/bsmain/test_vacuum.py
+++ b/bsmain/test_vacuum.py
@@ -1,0 +1,97 @@
+import io
+from datetime import timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.core.management import call_command
+from django.utils import timezone
+
+from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
+from events.factories import create_event
+from files.models import Chunk, File, FileMetadata
+from issues.factories import get_or_create_issue
+from projects.models import Project
+from tags.models import IssueTag, TagKey, TagValue, store_tags
+
+
+class VacuumCommandTestCase(TransactionTestCase):
+    # Auto-generated tests; not carefully reviewed but "at least this touches some code paths"
+
+    def test_vacuum_defaults_to_all_cleanup_families(self):
+        project = Project.objects.create(name="T")
+        old = timezone.now() - timedelta(days=100)
+
+        chunk = Chunk.objects.create(checksum="c" * 40, size=1, data=b"x")
+        Chunk.objects.filter(id=chunk.id).update(created_at=old)
+
+        orphan_key = TagKey.objects.create(project=project, key="orphan")
+        TagValue.objects.create(project=project, key=orphan_key, value="orphan")
+
+        issue, _ = get_or_create_issue(project)
+        event = create_event(project, issue=issue)
+        store_tags(event, issue, {"stale": "value"})
+        event.delete_deferred()
+
+        call_command("vacuum", stdout=io.StringIO())
+
+        self.assertFalse(Chunk.objects.exists())
+        self.assertFalse(IssueTag.objects.exists())
+        self.assertFalse(TagValue.objects.exists())
+        self.assertFalse(TagKey.objects.exists())
+
+    @patch("files.tasks.VACUUM_FILES_BATCH_SIZE", 2)
+    def test_vacuum_files_runs_inline_to_completion(self):
+        old = timezone.now() - timedelta(days=100)
+
+        old_chunks = [
+            Chunk.objects.create(checksum=f"{i:040d}", size=1, data=b"x")
+            for i in range(3)
+        ]
+        Chunk.objects.filter(id__in=[chunk.id for chunk in old_chunks]).update(created_at=old)
+
+        recent_chunk = Chunk.objects.create(checksum="9" * 40, size=1, data=b"x")
+
+        old_file = File.objects.create(checksum="a" * 40, filename="old.js.map", size=1, data=b"x")
+        File.objects.filter(id=old_file.id).update(accessed_at=old)
+        FileMetadata.objects.create(file=old_file, debug_id=uuid4(), file_type="source_map", data="{}")
+
+        recent_file = File.objects.create(checksum="b" * 40, filename="recent.js.map", size=1, data=b"x")
+        FileMetadata.objects.create(file=recent_file, debug_id=uuid4(), file_type="source_map", data="{}")
+
+        call_command("vacuum", "--files", stdout=io.StringIO())
+
+        self.assertEqual([recent_chunk.id], list(Chunk.objects.values_list("id", flat=True)))
+        self.assertEqual([recent_file.id], list(File.objects.values_list("id", flat=True)))
+        self.assertEqual([recent_file.id], list(FileMetadata.objects.values_list("file_id", flat=True)))
+
+    @patch("tags.tasks.VACUUM_TAGS_BATCH_SIZE", 2)
+    def test_vacuum_tags_runs_inline_to_completion(self):
+        project = Project.objects.create(name="T")
+        issue, _ = get_or_create_issue(project)
+
+        used_key = TagKey.objects.create(project=project, key="used")
+        used_value = TagValue.objects.create(project=project, key=used_key, value="still-used")
+        IssueTag.objects.create(project=project, key=used_key, value=used_value, issue=issue, count=1)
+
+        for i in range(3):
+            orphan_key = TagKey.objects.create(project=project, key=f"orphan-{i}")
+            TagValue.objects.create(project=project, key=orphan_key, value=f"value-{i}")
+
+        call_command("vacuum", "--tags", stdout=io.StringIO())
+
+        self.assertEqual([used_value.id], list(TagValue.objects.values_list("id", flat=True)))
+        self.assertEqual([used_key.id], list(TagKey.objects.values_list("id", flat=True)))
+
+    @patch("tags.tasks.VACUUM_EVENTLESS_ISSUETAGS_BATCH_SIZE", 2)
+    @patch("tags.tasks.VACUUM_EVENTLESS_ISSUETAGS_INNER_BATCH_SIZE", 1)
+    def test_vacuum_eventless_issuetags_runs_inline_to_completion(self):
+        project = Project.objects.create(name="T")
+        issue, _ = get_or_create_issue(project)
+        event = create_event(project, issue=issue)
+        store_tags(event, issue, {f"key-{i}": f"value-{i}" for i in range(3)})
+        event.delete_deferred()
+
+        call_command("vacuum", "--eventless-issuetags", stdout=io.StringIO())
+
+        self.assertFalse(IssueTag.objects.exists())
+        self.assertFalse(TagValue.objects.exists())

--- a/files/management/commands/vacuum_files.py
+++ b/files/management/commands/vacuum_files.py
@@ -3,7 +3,7 @@ from files.tasks import vacuum_files
 
 
 class Command(BaseCommand):
-    help = "Kick off (sourcemaps-)files cleanup by vacuuming old entries."
+    help = "Kick off (async, in snappea) (sourcemaps-)files cleanup by vacuuming old entries."
 
     def add_arguments(self, parser):
         # default of chunk_max_days=1 is already quite long... Chunks are used immediately, or not at all.

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -19,6 +19,11 @@ from .models import Chunk, File, FileMetadata
 logger = logging.getLogger("bugsink.api")
 
 
+# budget is not yet tuned; reasons for high values: we're dealing with "leaves in the model-dep-tree here"; reasons for
+# low values: deletion of files might just be expensive.
+VACUUM_FILES_BATCH_SIZE = 500
+
+
 # "In the wild", we have run into non-unique debug IDs (one in code, one in comment-at-bottom). This regex matches a
 # known pattern for "one in code", such that we can at least warn if it's not the same at the actually reported one.
 # See #157
@@ -155,11 +160,21 @@ def record_file_accesses(metadata_ids, accessed_at):
 
 @shared_task
 def vacuum_files(chunk_max_days=1, file_max_days=90):
-    now = timezone.now()
+    if vacuum_files_batch(chunk_max_days=chunk_max_days, file_max_days=file_max_days):
+        # possibly more to delete, so we re-schedule the task
+        delay_on_commit(vacuum_files, chunk_max_days=chunk_max_days, file_max_days=file_max_days)
+
+
+def vacuum_files_sync(chunk_max_days=1, file_max_days=90):
+    # possibly more to delete, so we re-schedule the task
+    while vacuum_files_batch(chunk_max_days=chunk_max_days, file_max_days=file_max_days):
+        pass
+
+
+def vacuum_files_batch(chunk_max_days=1, file_max_days=90):
+    # returns True when there may be more work to do.
     with immediate_atomic():
-        # budget is not yet tuned; reasons for high values: we're dealing with "leaves in the model-dep-tree here";
-        # reasons for low values: deletion of files might just be expensive.
-        budget = 500
+        now = timezone.now()
         num_deleted = 0
 
         for model, field_name, max_days in [
@@ -168,9 +183,12 @@ def vacuum_files(chunk_max_days=1, file_max_days=90):
             # for FileMetadata we rely on cascading from File (which will always happen "eventually")
                 ]:
 
-            while num_deleted < budget:
-                ids = (model.objects.filter(**{f"{field_name}__lt": now - timedelta(days=max_days)})[:budget].
-                       values_list('id', flat=True))
+            while num_deleted < VACUUM_FILES_BATCH_SIZE:
+                ids = list(
+                    model.objects
+                    .filter(**{f"{field_name}__lt": now - timedelta(days=max_days)})[:VACUUM_FILES_BATCH_SIZE]
+                    .values_list('id', flat=True)
+                )
 
                 if len(ids) == 0:
                     break
@@ -178,6 +196,5 @@ def vacuum_files(chunk_max_days=1, file_max_days=90):
                 model.objects.filter(id__in=ids).delete()
                 num_deleted += len(ids)
 
-        if num_deleted == budget:
-            # budget exhausted but possibly more to delete, so we re-schedule the task
-            delay_on_commit(vacuum_files, chunk_max_days=chunk_max_days, file_max_days=file_max_days)
+        # budget exhausted but possibly more to delete
+        return num_deleted == VACUUM_FILES_BATCH_SIZE

--- a/tags/management/commands/vacuum_eventless_issuetags.py
+++ b/tags/management/commands/vacuum_eventless_issuetags.py
@@ -3,7 +3,8 @@ from tags.tasks import vacuum_eventless_issuetags
 
 
 class Command(BaseCommand):
-    help = "Kick off tag cleanup by vacuuming IssueTag objects for which there is no EventTag equivalent"
+    help = ("Kick off (async, in snappea) tag cleanup by vacuuming IssueTag objects for which there is no EventTag "
+            "equivalent")
 
     def handle(self, *args, **options):
         vacuum_eventless_issuetags.delay()

--- a/tags/management/commands/vacuum_tags.py
+++ b/tags/management/commands/vacuum_tags.py
@@ -3,7 +3,7 @@ from tags.tasks import vacuum_tagvalues
 
 
 class Command(BaseCommand):
-    help = "Kick off tag cleanup by vacuuming orphaned TagValue and TagKey entries."
+    help = "Kick off (async, in snappea) tag cleanup by vacuuming orphaned TagValue and TagKey entries."
 
     def handle(self, *args, **options):
         vacuum_tagvalues.delay()

--- a/tags/tasks.py
+++ b/tags/tasks.py
@@ -6,12 +6,48 @@ from bugsink.moreiterutils import batched
 from bugsink.transaction import immediate_atomic, delay_on_commit
 from tags.models import TagValue, TagKey, EventTag, IssueTag, _or_join, prune_tagvalues
 
-BATCH_SIZE = 10_000
+VACUUM_TAGS_BATCH_SIZE = 10_000
+VACUUM_EVENTLESS_ISSUETAGS_BATCH_SIZE = 2048
+VACUUM_EVENTLESS_ISSUETAGS_INNER_BATCH_SIZE = 64
 
 
 @shared_task
 def vacuum_tagvalues(min_id=0):
-    # This task cleans up unused TagValue in batches. A TagValue can be unused if no IssueTag or EventTag references it,
+    # Known limitation:
+    # with _many_ TagValues (whether used or not) and when running in EAGER mode, this thing overflows the stack.
+    # Basically: because then the "delayed recursion" is not actually delayed, it just runs immediately. Answer: for
+    # "big things" (basically: serious setups) set up snappea or call the sync version (which uses a loop).
+
+    next_min_id = vacuum_tagvalues_batch(min_id=min_id)
+    if next_min_id is None:
+        # Done with TagValues → start TagKey cleanup
+        delay_on_commit(vacuum_tagkeys, 0)
+        return
+
+    vacuum_tagvalues.delay(next_min_id)
+
+
+def vacuum_tags_sync():
+    min_id = 0
+    while True:
+        min_id = vacuum_tagvalues_batch(min_id=min_id)
+        if min_id is None:
+            break
+
+    # Done with TagValues → start TagKey cleanup
+    vacuum_tagkeys_sync()
+
+
+def vacuum_tagkeys_sync():
+    min_id = 0
+    while True:
+        min_id = vacuum_tagkeys_batch(min_id=min_id)
+        if min_id is None:
+            return  # done
+
+
+def vacuum_tagvalues_batch(min_id=0):
+    # This cleans up unused TagValue in batches. A TagValue can be unused if no IssueTag or EventTag references it,
     # this can happen if IssueTag or EventTag entries are deleted. Cleanup is avoided in that case to avoid repeated
     # checks. But it still needs to be done eventually to avoid bloating the database, which is what this task does.
 
@@ -21,24 +57,17 @@ def vacuum_tagvalues(min_id=0):
     #   TagValue.exclude(some_usage_pattern) which may be slow / for which reasoning about performance is hard.
     # * batched to allow for incremental cleanup, using a defer-with-min-id pattern to implement the batching.
     #
-    # Known limitation:
-    # with _many_ TagValues (whether used or not) and when running in EAGER mode, this thing overflows the stack.
-    # Basically: because then the "delayed recursion" is not actually delayed, it just runs immediately. Answer: for
-    # "big things" (basically: serious setups) set up snappea.
-
     with immediate_atomic():
-        # Select candidate TagValue IDs above min_id
+        # Select candidate TagValue IDs strictly greater than min_id
         ids_to_check = list(
             TagValue.objects
             .filter(id__gt=min_id)
             .order_by('id')
-            .values_list('id', flat=True)[:BATCH_SIZE]
+            .values_list('id', flat=True)[:VACUUM_TAGS_BATCH_SIZE]
         )
 
         if not ids_to_check:
-            # Done with TagValues → start TagKey cleanup
-            delay_on_commit(vacuum_tagkeys, 0)
-            return
+            return None
 
         # Determine which ids_to_check are referenced
         used_in_event = set(
@@ -54,23 +83,32 @@ def vacuum_tagvalues(min_id=0):
         if unused:
             TagValue.objects.filter(id__in=unused).delete()
 
-    # Defer next batch
-    vacuum_tagvalues.delay(ids_to_check[-1])
+        # Return the last ID we checked as the new min_id for the next batch. This is correct because we select IDs
+        # strictly greater than min_id.
+        return ids_to_check[-1]
 
 
 @shared_task
 def vacuum_tagkeys(min_id=0):
+    next_min_id = vacuum_tagkeys_batch(min_id=min_id)
+    if next_min_id is None:
+        return  # done
+
+    vacuum_tagkeys.delay(next_min_id)  # defer next batch
+
+
+def vacuum_tagkeys_batch(min_id=0):
     with immediate_atomic():
-        # Select candidate TagKey IDs above min_id
+        # Select candidate TagKey IDs strictly greater than min_id
         ids_to_check = list(
             TagKey.objects
             .filter(id__gt=min_id)
             .order_by('id')
-            .values_list('id', flat=True)[:BATCH_SIZE]
+            .values_list('id', flat=True)[:VACUUM_TAGS_BATCH_SIZE]
         )
 
         if not ids_to_check:
-            return  # done
+            return None
 
         # Determine which ids_to_check are referenced
         used = set(
@@ -83,12 +121,27 @@ def vacuum_tagkeys(min_id=0):
         if unused:
             TagKey.objects.filter(id__in=unused).delete()
 
-    # Defer next batch
-    vacuum_tagkeys.delay(ids_to_check[-1])
+        return ids_to_check[-1]
 
 
 @shared_task
 def vacuum_eventless_issuetags(min_id=0):
+    next_min_id = vacuum_eventless_issuetags_batch(min_id=min_id)
+    if next_min_id is None:
+        return
+
+    vacuum_eventless_issuetags.delay(next_min_id)
+
+
+def vacuum_eventless_issuetags_sync():
+    min_id = 0
+    while True:
+        min_id = vacuum_eventless_issuetags_batch(min_id=min_id)
+        if min_id is None:
+            return
+
+
+def vacuum_eventless_issuetags_batch(min_id=0):
     # This task removes IssueTag entries that are no longer referenced by any EventTag for an Event on the same Issue.
     #
     # Under normal operation, we evict Events and their EventTags. However, we do not track how many EventTags back
@@ -107,21 +160,19 @@ def vacuum_eventless_issuetags(min_id=0):
     # edge of the object-graph" than for e.g. even-retention, so we can both afford bigger batches (less cascading
     # effects per item) as well as need bigger batches (because there are more expected items in a fanning-out
     # object-graph).
-    BATCH_SIZE = 2048
 
     # Community wisdom (says ChatGPT, w/o source): queries with dozens of OR clauses can slow down significantly. 64 is
     # a safe, batch size that avoids planner overhead and keeps things fast across databases.
-    INNER_BATCH_SIZE = 64
 
     with immediate_atomic():
         issue_tag_infos = list(
             IssueTag.objects
             .filter(id__gt=min_id)
             .order_by('id')
-            .values('id', 'issue_id', 'value_id')[:BATCH_SIZE]
+            .values('id', 'issue_id', 'value_id')[:VACUUM_EVENTLESS_ISSUETAGS_BATCH_SIZE]
         )
 
-        for issue_tag_infos_batch in batched(issue_tag_infos, INNER_BATCH_SIZE):
+        for issue_tag_infos_batch in batched(issue_tag_infos, VACUUM_EVENTLESS_ISSUETAGS_INNER_BATCH_SIZE):
             matching_eventtags = _or_join([
                 Q(issue_id=it['issue_id'], value_id=it['value_id']) for it in issue_tag_infos_batch
             ])
@@ -148,10 +199,11 @@ def vacuum_eventless_issuetags(min_id=0):
                 # prune_orphans.
                 prune_tagvalues([it['value_id'] for it in stale_issuetags])
 
-    if not issue_tag_infos:
-        # We don't have a continuation for the "done" case. One could argue: kick off vacuum_tagvalues there, but I'd
-        # rather rather build the toolbox of cleanup tasks first and see how they might fit together later. Because the
-        # downside of triggering the next vacuum command would be that "more things might happen too soon".
-        return
+        if not issue_tag_infos:
+            # We don't have a continuation for the "done" case. One could argue: kick off vacuum_tagvalues there, but
+            # I'd rather rather build the toolbox of cleanup tasks first and see how they might fit together later.
+            # Because the
+            # downside of triggering the next vacuum command would be that "more things might happen too soon".
+            return None
 
-    vacuum_eventless_issuetags.delay(issue_tag_infos[-1]['id'])
+        return issue_tag_infos[-1]['id']


### PR DESCRIPTION
This is easier to call than various separate ones; it's also useful in contexts where waiting for completion is desirable.

The old `vacuum_files`, `vacuum_tags`, and `vacuum_eventless_issuetags` commands stay around as explicit async wrappers for ad hoc admin use.