### PR TITLE
Refresh issue title fields on every event digest

### DIFF
--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -1044,6 +1044,33 @@ class IngestViewTestCase(TransactionTestCase):
         self.assertEqual(2, Issue.objects.get().stored_event_count)
         self.assertEqual(2, Project.objects.get(id=self.quiet_project.id).stored_event_count)
 
+    def test_ingest_refreshes_issue_calculated_fields_on_subsequent_events(self):
+        # When a fingerprint groups events whose exception type/value differ, the issue's denormalized
+        # calculated_type/calculated_value should reflect the latest event so that the displayed title
+        # tracks reality instead of staying frozen on the first event.
+        request = self.request_factory.post("/api/1/store/")
+
+        first = create_event_data()
+        first["exception"] = {"values": [{"type": "FirstError", "value": "first message"}]}
+        first["fingerprint"] = ["shared-fingerprint"]
+        BaseIngestAPIView().digest_event(**_digest_params(first, self.quiet_project, request))
+
+        issue = Issue.objects.get()
+        self.assertEqual("FirstError", issue.calculated_type)
+        self.assertEqual("first message", issue.calculated_value)
+
+        second = create_event_data()
+        second["exception"] = {"values": [{"type": "SecondError", "value": "second message"}]}
+        second["fingerprint"] = ["shared-fingerprint"]
+        BaseIngestAPIView().digest_event(**_digest_params(second, self.quiet_project, request))
+
+        # still a single issue (same fingerprint), but its title fields now reflect the most recent event
+        self.assertEqual(1, Issue.objects.count())
+        issue.refresh_from_db()
+        self.assertEqual("SecondError", issue.calculated_type)
+        self.assertEqual("second message", issue.calculated_value)
+        self.assertEqual(2, issue.digested_event_count)
+
 
 class MinidumpAPIViewTestCase(TransactionTestCase):
     # NOTE: no tests for the _actual_ minidump processing just yet.

--- a/ingest/views.py
+++ b/ingest/views.py
@@ -395,9 +395,12 @@ class BaseIngestAPIView(View):
             issue = grouping.issue
             issue_created = False
 
-            # update the denormalized fields
+            # update the denormalized fields; calculated_type/value track the latest event so the issue title
+            # reflects the most recent exception (otherwise it stays frozen to the first event's message).
             issue.last_seen = ingested_at
             issue.digested_event_count += 1
+            issue.calculated_type = calculated_type
+            issue.calculated_value = calculated_value
 
         except Grouping.DoesNotExist:
             # we don't have Project.issue_count here ('premature optimization') so we just do an aggregate instead.


### PR DESCRIPTION
## Symptom

When a fingerprint groups events whose exception type or value differ, an issue's displayed title stays frozen on the very first event's exception even though later events under the same grouping carry different and often more relevant messages. This is the standard Sentry-SDK case: the SDK ships a stacktrace-based fingerprint, the exception value varies between calls, and the bugsink UI keeps showing the first one indefinitely.

## Cause

In `BaseIngestAPIView.digest_event`, `get_type_and_value_for_data` runs for every event and the result is denormalized onto the Issue, but only when a *new* Issue is created. The existing-issue branch updates `last_seen` and `digested_event_count` yet leaves `calculated_type` and `calculated_value` untouched, so they reflect the first event forever.

## Fix

Mirror the `last_seen` semantics: also assign the freshly computed `calculated_type` and `calculated_value` on every digest. The `issue.save()` further down in the same method already persists them, no migration is needed, and `Issue.title()` / the templates pick up the change because they read straight from those fields.

## Test plan

- [x] New ingest test sends two events sharing a fingerprint but carrying different exception type and value; the second event's values must show up on the (still single) issue. Verified to fail without the patch and pass with it.
- [x] `python manage.py test ingest issues events --exclude-tag=samples` — 145 tests pass.
- [x] `ruff check ingest/views.py ingest/tests.py` — clean.
- [x] Smoke-tested in production by bind-mounting the patched file over `bugsink/bugsink:2.1.3` for a few hours; titles now track the latest event as expected.

Happy to sign the CLA when the bot prompts.