### PR TITLE
fix: generate event_id on /store/ when missing (closes #383)

### DIFF
--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -554,6 +554,35 @@ class IngestViewTestCase(TransactionTestCase):
 
             self.assertEqual(0, Event.objects.count())
 
+    def test_store_endpoint_generates_event_id_when_missing(self):
+        # The legacy /store/ endpoint must accept payloads without `event_id` and generate one server-side
+        # (matching real Sentry behavior). utopia-php/logger — used by Appwrite 1.9.0 — posts without `event_id`.
+        project = Project.objects.create(name="test")
+
+        sentry_auth_header = get_header_value(f"http://{ project.sentry_key }@hostisignored/{ project.id }")
+
+        data = {
+            "timestamp": time.time(),
+            "platform": "php",
+            "level": "error",
+            "logger": "app",
+            "message": {"message": "test"},
+            "exception": {"values": [{"type": "TestError", "stacktrace": {"frames": []}}]},
+        }
+        data_bytes = json.dumps(data).encode("utf-8")
+
+        response = self.client.post(
+            f"/api/{ project.id }/store/",
+            content_type="application/json",
+            headers={
+                "X-Sentry-Auth": sentry_auth_header,
+            },
+            data=data_bytes,
+        )
+        self.assertEqual(
+            200, response.status_code, response.content if response.status_code != 302 else response.url)
+        self.assertEqual(1, Event.objects.count())
+
     def test_envelope_endpoint_cleans_up_oversized_event_file(self):
         project = Project.objects.create(name="test")
         sentry_auth_header = get_header_value(f"http://{ project.sentry_key }@hostisignored/{ project.id }")

--- a/ingest/views.py
+++ b/ingest/views.py
@@ -708,6 +708,8 @@ class IngestEventAPIView(BaseIngestAPIView):
         performance_logger.info("ingested event with %s bytes", len(event_data_bytes))
 
         event_data = json.loads(event_data_bytes)
+        if "event_id" not in event_data:
+            event_data["event_id"] = uuid.uuid4().hex
         filename = get_filename_for_event_id(ingestion_id)
         b108_makedirs(os.path.dirname(filename))
         with open(filename, 'w') as f:


### PR DESCRIPTION
## Summary

Fixes #383. The legacy `/store/` endpoint crashed with `KeyError: 'event_id'` on spec-compliant payloads that omit `event_id`. Per the [Sentry event payload spec](https://develop.sentry.dev/sdk/event-payloads/), `event_id` is recommended but not strictly required on `/store/` — the server should generate one if missing. Real Sentry accepts these payloads; this change aligns BugSink with that behavior.

## Change

Mirror the minidump handler pattern already in `views.py:244`: when `event_id` is absent from the posted event data, generate one with `uuid.uuid4().hex` before writing to disk and scheduling the digest task.

```python
event_data = json.loads(event_data_bytes)
if "event_id" not in event_data:
    event_data["event_id"] = uuid.uuid4().hex
```

Only `IngestEventAPIView._post` (the `/store/` handler) is touched. The envelope endpoint already handles missing `event_id` correctly via `ParseError` at the envelope header level.

## Test

Added `test_store_endpoint_generates_event_id_when_missing` in `ingest/tests.py` — an integration test that posts a utopia-php/logger-shaped payload (no `event_id`) to `/api/{project_id}/store/` and asserts a 200 response with one stored event.

```
$ python manage.py test ingest.tests.IngestViewTestCase.test_store_endpoint_generates_event_id_when_missing
Ran 1 test in 0.212s
OK
```

`ruff check .` also clean.

## Real-world impact

[Appwrite 1.9.0](https://github.com/appwrite/appwrite) self-hosted uses [utopia-php/logger 0.6.2](https://github.com/utopia-php/logger/blob/0.6.2/src/Logger/Adapter/Sentry.php) as its Sentry adapter. It posts to `/api/{projectId}/store/` without `event_id`. Every Appwrite error — main container, workers, openruntimes executor — fails to ingest when BugSink is the backend, surfacing as:

```
Failed to push log: Log could not be pushed with status code 500: 'event_id'
```

After this fix, Appwrite errors ingest cleanly without any sidecar proxy or SDK workaround.

## Notes

- I left the separate `timestamp` concern mentioned in the issue for a follow-up — the digest task's `KeyError: 'timestamp'` is in a different code path and not exercised by the `/store/` ingest itself.
- `/store/` remains deprecated; this change only makes it accept spec-compliant payloads so PHP-based SDKs that still default to `/store/` work out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)