### PR TITLE
Show human readable memory info for .NET issues

### DIFF
--- a/issues/templates/issues/event_details.html
+++ b/issues/templates/issues/event_details.html
@@ -140,7 +140,17 @@
             {% for key, value in context|items %}
                 <div class="flex {% if forloop.first %}border-slate-300 dark:border-slate-600 border-t-2{% endif %}">
                     <div class="w-1/4 {% if not forloop.last %}border-b-2 border-dotted border-slate-300 dark:border-slate-600{% endif %}">{{ key }}</div>
-                    <div class="w-3/4 {% if not forloop.last %} border-b-2 border-dotted border-slate-300 dark:border-slate-600{% endif %} font-mono">{{ value|linebreaks }}</div>
+                    <div class="w-3/4 {% if not forloop.last %} border-b-2 border-dotted border-slate-300 dark:border-slate-600{% endif %} font-mono">
+                        {% if context_key == "Memory Info" %}
+                            {% if key == "total_allocated_bytes" or key == "fragmented_bytes" or key == "heap_size_bytes" or key == "high_memory_load_threshold_bytes" or key == "total_available_memory_bytes" or key == "memory_load_bytes" or key == "total_committed_bytes" or key == "promoted_bytes" %}
+                                {{ value|intcomma }} bytes ({{ value|filesizeformat }})
+                            {% else %}
+                                {{ value|linebreaks }}
+                            {% endif %}
+                        {% else %}
+                            {{ value|linebreaks }}
+                        {% endif %}
+                    </div>
                 </div>
             {% endfor %}
         {% endfor %}


### PR DESCRIPTION
Hi!

The .NET SDK reports memory information in bytes that got displayed as regular integers.

This adds commas on the bytes and larger units (KB,MB,TB) in parentheses for much easier reading.

Before:
<img width="586" height="251" alt="Screenshot 2026-05-13 at 14 53 22" src="https://github.com/user-attachments/assets/353675ba-54d5-4f41-82e5-c7dcd6ff501e" />

After:
<img width="756" height="251" alt="Screenshot 2026-05-13 at 14 50 48" src="https://github.com/user-attachments/assets/aad52844-f429-49a4-b006-664df0f3d715" />

I'm submitting this pull request but understand if you decide not to merge it since this is will be mostly for .NET and I'm not sure if other language's SDK's also send similar parameters so this may not be a good or thorough enough patch. 🤷‍♂️ 

Cheers 👍 