### PR TITLE
Fix health check path wrong use of startswith

### DIFF
--- a/bugsink/wsgi.py
+++ b/bugsink/wsgi.py
@@ -94,7 +94,7 @@ class CustomWSGIRequest(WSGIRequest):
         We're leaking a bit of information here, but I don't think it's too much TBH -- especially in the light of ssl
         certificates being specifically tied to the domain name.
         """
-        if self.path.startswith == "/health/":
+        if self.path.startswith("/health/"):
             # For /health/ endpoints, we skip the ALLOWED_HOSTS validation (see #140).
             return self._get_raw_host()
 


### PR DESCRIPTION
This pull request fixes a bug in the `get_host` method in `bugsink/wsgi.py` related to the validation of the `/health/` endpoint. The change corrects the usage of the `startswith` method to properly check if the path begins with `/health/`, ensuring that the ALLOWED_HOSTS validation is correctly skipped for health check endpoints.

- Bug fix:
  * Corrected the call to `self.path.startswith` by adding parentheses, so `/health/` endpoints are properly detected and bypass ALLOWED_HOSTS validation as intended.