### PR TITLE
Create home directory by default during useradd in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt update && apt install -y git
 RUN pip install -e .
 
 RUN groupadd --gid 14237 bugsink \
- && useradd --uid 14237 --gid 14237 bugsink \
+ && useradd --uid 14237 --gid 14237 --create-home bugsink \
  && mkdir -p /data \
  && chown -R bugsink:bugsink /data
 

--- a/Dockerfile.fromwheel
+++ b/Dockerfile.fromwheel
@@ -73,7 +73,7 @@ RUN cp /usr/local/lib/python3.12/site-packages/bugsink/conf_templates/docker.py.
     cp /usr/local/lib/python3.12/site-packages/bugsink/gunicorn.docker.conf.py /app/gunicorn.docker.conf.py
 
 RUN groupadd --gid 14237 bugsink \
- && useradd --uid 14237 --gid 14237 bugsink \
+ && useradd --uid 14237 --gid 14237 --create-home bugsink \
  && mkdir -p /data \
  && chown -R bugsink:bugsink /data
 


### PR DESCRIPTION
This pull request makes a small but important change to both the `Dockerfile` and `Dockerfile.fromwheel` files. The main update is to the way the `bugsink` user is created: the `--create-home` flag is now included, ensuring that a home directory is created for the user. This can help avoid issues where applications expect the user to have a home directory.

Most important change:

* Added the `--create-home` flag to the `useradd` command when creating the `bugsink` user, ensuring a home directory is created. (`Dockerfile` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L51-R51) `Dockerfile.fromwheel` [[2]](diffhunk://#diff-f77c068cfeb7d622992a891cd4076a256a14c497ab237239b40b5bb6d3d0b16bL76-R76)