### PR TITLE
Disable Gunicorn control socket in Docker

### DIFF
--- a/bugsink/gunicorn.docker.conf.py
+++ b/bugsink/gunicorn.docker.conf.py
@@ -1,4 +1,5 @@
 # gunicorn config file for Docker deployments
 import multiprocessing
 
+control_socket_disable = True
 workers = min(multiprocessing.cpu_count(), 4)


### PR DESCRIPTION
The Docker image does not use Gunicorn's runtime control socket, and recent gunicorn versions try to create it under a runtime/home directory by default. Avoid the unnecessary socket setup and its log noise by disabling it explicitly in the Docker Gunicorn config.

See https://github.com/bugsink/bugsink/pull/398#issuecomment-4518718281