### PR TITLE
GitHub CI/CD: upgrade 'checkout' and 'setup-python' actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: "Set up Python 3.12"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - name: Install Ruff
@@ -40,10 +40,10 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 
@@ -106,9 +106,9 @@ jobs:
       DB_USER: ${{ matrix.db_user }}
       DB_PASSWORD: ${{ matrix.db_password }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Start MySQL If Needed
@@ -134,7 +134,7 @@ jobs:
         pip install -r requirements.development.txt
         pip install mysqlclient psycopg2
     - name: Check out event-samples
-      uses: actions/checkout@master
+      uses: actions/checkout@v6
       with:
         repository: bugsink/event-samples
         path: "event-samples"
@@ -169,7 +169,7 @@ jobs:
     # Build the Docker image, start it, wait for readiness, log in at /accounts/login/,
     # and verify that / redirects to /teams/.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build Docker image
         run: docker build -t bugsink-ci .

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,14 +19,14 @@ jobs:
       SAMPLES_DIR: ${{ github.workspace }}/event-samples
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install project `pre-commit` hook
         run: |
           cp pre-commit .git/hooks/pre-commit
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
> Warning: Node.js 20 actions are deprecated. The following actions are running
> on Node.js 20 and may not work as expected: actions/checkout@v4....