### PR TITLE
Update docker run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker pull bugsink/bugsink:latest
 
 docker run \
   -e SECRET_KEY=PUT_AN_ACTUAL_RANDOM_SECRET_HERE_OF_AT_LEAST_50_CHARS \
-  -e CREATE_SUPERUSER=admin:admin \
+  -e CREATE_SUPERUSER=admin@example.org:admin \
   -e PORT=8000 \
   -p 8000:8000 \
   bugsink/bugsink


### PR DESCRIPTION
It seems like `CREATE_SUPERUSER` validation was changed in https://github.com/bugsink/bugsink/issues/394 but the installation examples from README.md and [documentation](https://www.bugsink.com/docs/installation/) were not updated.

New users, myself included, will be greeted with an error when they run the command to spin up Bugsink.
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/bsmain/management/commands/prestart.py", line 36, in _create_superuser_if_needed
    validate_email(username)
  File "/usr/local/lib/python3.12/site-packages/django/core/validators.py", line 248, in __call__
    raise ValidationError(self.message, code=self.code, params={"value": value})
django.core.exceptions.ValidationError: ['Enter a valid email address.']

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/bugsink-manage", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bugsink/scripts/manage.py", line 29, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bsmain/management/commands/prestart.py", line 44, in handle
    self._create_superuser_if_needed()
  File "/usr/local/lib/python3.12/site-packages/bsmain/management/commands/prestart.py", line 38, in _create_superuser_if_needed
    raise ValueError("CREATE_SUPERUSER email should be a valid email address") from e
ValueError: CREATE_SUPERUSER email should be a valid email address
```