### PR TITLE
Add tzdata to requirements so named timezones resolve in Docker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ ecma426>=0.2.0
 djangorestframework==3.17.*
 drf-spectacular[sidecar]
 symbolic==8.7.2  # the last version to support ProcessState (i.e. minidump parsing)
+tzdata  # ship the IANA tz database; python:*-slim has no system /usr/share/zoneinfo


### PR DESCRIPTION
The published Docker image builds `FROM python:3.12-slim`. The Debian slim base omits the system `tzdata` package, so there is no populated `/usr/share/zoneinfo`. On Python 3.9+ `zoneinfo` resolves named zones first from the OS tz database and then from the PyPI `tzdata` package — neither is present in the image, so both paths are empty.

With `USE_TZ = True` (settings/default.py) and `TIME_ZONE = os.getenv("TIME_ZONE", "UTC")` (conf_templates/docker.py.template), setting `TIME_ZONE` to a named zone such as `Europe/Amsterdam` raises:

```
zoneinfo._common.ZoneInfoNotFoundError: No time zone found with key Europe/Amsterdam
```

`UTC` happens to work because it is special-cased and never touches the tz database — which masks the issue until someone sets a real zone.

This PR adds `tzdata` to `requirements.txt`, giving `zoneinfo` an OS-independent source for the IANA database. This is preferable to `apt install tzdata` because it works for both `Dockerfile` and `Dockerfile.fromwheel` and keeps the behaviour consistent with the plain `pip install` path.

### Reproduce
```
docker run --rm bugsink/bugsink python -c "import zoneinfo; zoneinfo.ZoneInfo('Europe/Amsterdam')"
```
Fails before this change, succeeds after.