### PR TITLE
Decode percent-encoded components from DATABASE_URL after parsing

### DIFF
--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -1,7 +1,6 @@
 import os
-from urllib.parse import urlparse
 
-from bugsink.conf_utils import deduce_allowed_hosts, eat_your_own_dogfood, deduce_script_name, int_or_none
+from bugsink.conf_utils import deduce_allowed_hosts, eat_your_own_dogfood, deduce_script_name, int_or_none, parse_database_url
 
 from bugsink.settings.default import *  # noqa
 from bugsink.settings.default import DATABASES
@@ -84,32 +83,7 @@ DATABASES["snappea"]["NAME"] = '/tmp/snappea.sqlite3'
 
 
 if os.getenv("DATABASE_URL"):
-    DATABASE_URL = os.getenv("DATABASE_URL")
-    parsed = urlparse(DATABASE_URL)
-
-    if parsed.scheme == "mysql":
-        DATABASES['default'] = {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': parsed.path.lstrip('/'),
-            "USER": parsed.username,
-            "PASSWORD": parsed.password,
-            "HOST": parsed.hostname,
-            "PORT": parsed.port or "3306",
-        }
-
-    elif parsed.scheme in ["postgres", "postgresql"]:
-        DATABASES['default'] = {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': parsed.path.lstrip('/'),
-            "USER": parsed.username,
-            "PASSWORD": parsed.password,
-            "HOST": parsed.hostname,
-            "PORT": parsed.port or "5432",
-        }
-
-    else:
-        raise ValueError("For DATABASE_URL, only mysql and postgres are supported, not '%s'" % parsed.scheme)
-
+    DATABASES['default'] = parse_database_url(os.getenv("DATABASE_URL"))
 else:
     # similar to the default, but the fallback is /data/db.sqlite3; we also create the directory if it doesn't exist,
     # which allows for throwaway setups (no volume mounted) to work out of the box.

--- a/bugsink/conf_utils.py
+++ b/bugsink/conf_utils.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 
 from .version import version
@@ -51,6 +51,37 @@ def deduce_script_name(base_url):
         return None
 
     return path if path not in (None, "", "/") else None
+
+
+def parse_database_url(url):
+    """Parse DATABASE_URL into a Django DATABASES entry dict."""
+    parsed = urlparse(url)
+
+    # urlparse returns percent-encoded username/password/path; decode each component individually
+    # so that reserved characters (e.g. @ or : in a password) are passed to the driver correctly.
+    def _unquote(value):
+        return unquote(value) if value is not None else None
+
+    if parsed.scheme == "mysql":
+        return {
+            "ENGINE": "django.db.backends.mysql",
+            "NAME": unquote(parsed.path.lstrip("/")),
+            "USER": _unquote(parsed.username),
+            "PASSWORD": _unquote(parsed.password),
+            "HOST": parsed.hostname,
+            "PORT": parsed.port or "3306",
+        }
+    elif parsed.scheme in ["postgres", "postgresql"]:
+        return {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": unquote(parsed.path.lstrip("/")),
+            "USER": _unquote(parsed.username),
+            "PASSWORD": _unquote(parsed.password),
+            "HOST": parsed.hostname,
+            "PORT": parsed.port or "5432",
+        }
+    else:
+        raise ValueError("For DATABASE_URL, only mysql and postgres are supported, not '%s'" % parsed.scheme)
 
 
 def int_or_none(value):

--- a/bugsink/test_conf_utils.py
+++ b/bugsink/test_conf_utils.py
@@ -1,0 +1,78 @@
+from unittest import TestCase
+
+from .conf_utils import parse_database_url
+
+
+class ParseDatabaseUrlTestCase(TestCase):
+
+    def test_postgres_basic(self):
+        result = parse_database_url("postgresql://user:secret@localhost/bugsink")
+        self.assertEqual(result["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(result["USER"], "user")
+        self.assertEqual(result["PASSWORD"], "secret")
+        self.assertEqual(result["NAME"], "bugsink")
+        self.assertEqual(result["HOST"], "localhost")
+        self.assertEqual(result["PORT"], "5432")
+
+    def test_postgres_scheme_alias(self):
+        result = parse_database_url("postgres://user:secret@localhost/bugsink")
+        self.assertEqual(result["ENGINE"], "django.db.backends.postgresql")
+
+    def test_postgres_explicit_port(self):
+        result = parse_database_url("postgresql://user:secret@db.example.com:5433/bugsink")
+        self.assertEqual(result["HOST"], "db.example.com")
+        self.assertEqual(result["PORT"], 5433)
+
+    def test_postgres_percent_encoded_password(self):
+        # @ and : in a password must be percent-encoded in the URL
+        result = parse_database_url("postgresql://admin_usr_bugsink:p%40ss%3Aword@postgres.example.com:5432/bugsink")
+        self.assertEqual(result["USER"], "admin_usr_bugsink")
+        self.assertEqual(result["PASSWORD"], "p@ss:word")
+        self.assertEqual(result["NAME"], "bugsink")
+
+    def test_postgres_percent_encoded_username(self):
+        result = parse_database_url("postgresql://u%2Bser:secret@localhost/bugsink")
+        self.assertEqual(result["USER"], "u+ser")
+
+    def test_postgres_double_encoded_percent(self):
+        # %2525 in the URL -> %25 after one round of decoding -> the literal string %25
+        result = parse_database_url("postgresql://user:p%2525word@localhost/bugsink")
+        self.assertEqual(result["PASSWORD"], "p%25word")
+
+    def test_postgres_percent_encoded_dbname(self):
+        result = parse_database_url("postgresql://user:secret@localhost/bug%2Fsink")
+        self.assertEqual(result["NAME"], "bug/sink")
+
+    def test_postgres_no_credentials(self):
+        result = parse_database_url("postgresql://localhost/bugsink")
+        self.assertIsNone(result["USER"])
+        self.assertIsNone(result["PASSWORD"])
+
+    def test_mysql_basic(self):
+        result = parse_database_url("mysql://user:secret@localhost/bugsink")
+        self.assertEqual(result["ENGINE"], "django.db.backends.mysql")
+        self.assertEqual(result["USER"], "user")
+        self.assertEqual(result["PASSWORD"], "secret")
+        self.assertEqual(result["NAME"], "bugsink")
+        self.assertEqual(result["PORT"], "3306")
+
+    def test_mysql_percent_encoded_password(self):
+        result = parse_database_url("mysql://user:p%40ss%3Aword@localhost/bugsink")
+        self.assertEqual(result["PASSWORD"], "p@ss:word")
+
+    def test_mysql_percent_encoded_username(self):
+        result = parse_database_url("mysql://u%2Bser:secret@localhost/bugsink")
+        self.assertEqual(result["USER"], "u+ser")
+
+    def test_mysql_percent_encoded_dbname(self):
+        result = parse_database_url("mysql://user:secret@localhost/bug%2Fsink")
+        self.assertEqual(result["NAME"], "bug/sink")
+
+    def test_mysql_explicit_port(self):
+        result = parse_database_url("mysql://user:secret@localhost:3307/bugsink")
+        self.assertEqual(result["PORT"], 3307)
+
+    def test_unsupported_scheme_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            parse_database_url("sqlite:///path/to/db.sqlite3")
+        self.assertIn("sqlite", str(cm.exception))


### PR DESCRIPTION
Hi,

I'm evaluating Bugsink as a Sentry replacement, deploying via the Helm chart against a managed PostgreSQL instance where I have no control over the generated credentials. After several hours of chasing a connection error I traced the root cause to missing percent-decoding in the DATABASE_URL parsing. The managed instance had assigned a password containing reserved characters.

Connecting with a DATABASE_URL that contains reserved characters in the username, password, or database name fails with an authentication error. A password like `p@ss:word` must be percent-encoded in the URL as `p%40ss%3Aword`, but the literal encoded string was passed through to the database driver unchanged.

The cause is that `urlparse()` returns percent-encoded strings for `.username`, `.password`, and `.path`. Callers must call `unquote()` explicitly. Decoding the full URL before parsing is not an option: an unencoded `@` or `:` in the password would confuse the parser itself.

The fix decodes each component individually after `urlparse()`. The logic is extracted into `conf_utils.parse_database_url()` so that it can be tested without Django settings loading. Hostname and port are left unchanged.