### PR TITLE
Fix Auth Tokens: description edit applied to the wrong token

### DIFF
--- a/bsmain/templates/bsmain/auth_token_list.html
+++ b/bsmain/templates/bsmain/auth_token_list.html
@@ -56,7 +56,7 @@
                         {% endif %}
                     </div>
                     <div class="mt-1 hidden" id="description-edit-{{ auth_token.id }}">
-                        <input type="text" name="description" value="{{ auth_token.description }}" maxlength="255" class="border-2 border-slate-300 dark:border-slate-600 rounded-md px-2 py-1 text-sm w-80 dark:bg-slate-800 dark:text-slate-100" id="description-input-{{ auth_token.id }}">
+                        <input type="text" name="description-{{ auth_token.id }}" value="{{ auth_token.description }}" maxlength="255" class="border-2 border-slate-300 dark:border-slate-600 rounded-md px-2 py-1 text-sm w-80 dark:bg-slate-800 dark:text-slate-100" id="description-input-{{ auth_token.id }}">
                         <button type="submit" name="action" value="update_description:{{ auth_token.id }}" class="inline-block ml-2 text-sm font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 px-3 py-1 border-2 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 rounded-md">{% translate "Save" %}</button>
                         <button type="button" onclick="hideEditDescription({{ auth_token.id }})" class="inline-block ml-2 text-sm font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 px-3 py-1 border-2 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 rounded-md">{% translate "Cancel" %}</button>
                     </div>

--- a/bsmain/tests.py
+++ b/bsmain/tests.py
@@ -1,5 +1,13 @@
+from django.contrib.auth import get_user_model
 from django.core.checks import run_checks
 from django.test import SimpleTestCase, override_settings
+from django.urls import reverse
+
+from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
+
+from .models import AuthToken
+
+User = get_user_model()
 
 
 class SystemChecksTestCase(SimpleTestCase):
@@ -43,3 +51,29 @@ class SystemChecksTestCase(SimpleTestCase):
     )
     def test_email_sender_domain_check_allows_bugsink_domain_when_allowed_hosts_match(self):
         self.assertEqual([], self._warnings())
+
+
+class AuthTokenDescriptionUpdateTestCase(TransactionTestCase):
+    """Editing one token's description must not touch any other token (regression test)."""
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(
+            User.objects.create_superuser(username="admin", password="admin", email="admin@example.org"))
+
+    def test_update_description_targets_only_the_clicked_token(self):
+        token_1 = AuthToken.objects.create(description="first")
+        token_2 = AuthToken.objects.create(description="second")
+
+        # A single <form> wraps all rows, so the browser posts every row's description input.
+        response = self.client.post(reverse("auth_token_list"), {
+            "action": f"update_description:{token_1.pk}",
+            f"description-{token_1.pk}": "updated first",
+            f"description-{token_2.pk}": "second",
+        })
+        self.assertEqual(302, response.status_code)
+
+        token_1.refresh_from_db()
+        token_2.refresh_from_db()
+        self.assertEqual("updated first", token_1.description)
+        self.assertEqual("second", token_2.description)

--- a/bsmain/views.py
+++ b/bsmain/views.py
@@ -25,7 +25,7 @@ def auth_token_list(request):
 
         elif action == "update_description":
             auth_token = AuthToken.objects.get(pk=pk)
-            auth_token.description = request.POST.get('description', '')[:255]
+            auth_token.description = request.POST.get(f'description-{pk}', '')[:255]
             auth_token.save()
 
             messages.success(request, _('Description updated'))


### PR DESCRIPTION
## Problem

On the Auth Tokens page (`/bsmain/auth_tokens/`), editing a token's description misbehaves when more than one token exists:

- Editing the **first** token's description appears to do nothing.
- Editing the **second** token's description sets **both** tokens to the same value.

## Cause

All token rows are rendered inside a single `<form>`, and every row's description `<input>` used the same `name="description"`. On submit the browser sends one `description` value per row, so `request.POST.get('description')` in `auth_token_list` always returns the **last** row's value (`QueryDict.get` returns the final value for a repeated key).

The clicked row is identified correctly from the Save button (`action="update_description:<pk>"`), but it was then assigned some other row's text — collapsing descriptions toward the bottom row's value.

## Fix

Make the description field name row-specific (`name="description-<pk>"`), mirroring the `action="<verb>:<pk>"` convention already used on this page, and read that key in the view:

- `bsmain/templates/bsmain/auth_token_list.html` — `name="description"` → `name="description-{{ auth_token.id }}"`
- `bsmain/views.py` — `request.POST.get('description', ...)` → `request.POST.get(f'description-{pk}', ...)`

A formset was avoided on purpose: the codebase uses none, and per-row names are the smaller, more predictable change (consistent with `AGENTS.md`). The row `id` attributes were already unique and the inline JS keys off `id`, so neither is affected. No Tailwind classes changed, so the vendored `styles.css` is untouched.

## Test

Adds `AuthTokenDescriptionUpdateTestCase` in `bsmain/tests.py` (there was previously no test for this view). It creates two tokens, posts an update for the first while both rows' inputs are present, and asserts only the clicked token changes. The test fails on `main` (the token gets blanked) and passes with this fix.

Verified locally: `manage.py test bsmain` (15 tests) passes and `ruff check .` is clean.
