### PR TITLE
Use ready endpoint in compose healthcheck

### DIFF
--- a/docker-compose-sample.yaml
+++ b/docker-compose-sample.yaml
@@ -37,7 +37,7 @@ services:
       # X_FORWARDED_FOR_PROXY_COUNT: "1"
       BASE_URL: "http://localhost:8000"
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8000/\").raise_for_status()'"]
+      test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8000/health/ready\").raise_for_status()'"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
The example health-check kept probing / while the image later standardized on /health/ready.  Probing / follows the login redirect and creates noisy self-requests in access logs.

Historically: the sample compose healthcheck was created in 9a0c52dc5809 before the Dockerfile healthchecks (232d2d969d85)

Fix #409.