### PR TITLE
Add custom webhook destination for alerts

### DIFF
--- a/alerts/models.py
+++ b/alerts/models.py
@@ -5,6 +5,7 @@ from .service_backends.slack import SlackBackend
 from .service_backends.mattermost import MattermostBackend
 from .service_backends.discord import DiscordBackend
 from .service_backends.telegram import TelegramBackend
+from .service_backends.custom import CustomBackend
 
 
 def get_alert_service_kind_choices():
@@ -15,6 +16,7 @@ def get_alert_service_kind_choices():
         ("mattermost", "Mattermost"),
         ("slack", "Slack"),
         ("telegram", "Telegram"),
+        ("custom", "Custom"),
     ]
 
 
@@ -27,6 +29,8 @@ def get_alert_service_backend_class(kind):
         return SlackBackend
     if kind == "telegram":
         return TelegramBackend
+    if kind == "custom":
+        return CustomBackend
     raise ValueError(f"Unknown backend kind: {kind}")
 
 

--- a/alerts/service_backends/custom.py
+++ b/alerts/service_backends/custom.py
@@ -1,0 +1,192 @@
+import json
+
+import requests
+from django import forms
+from django.utils import timezone
+
+from bugsink.app_settings import get_settings
+from bugsink.transaction import immediate_atomic
+from issues.models import Issue
+from issues.serializers import IssueSerializer
+from snappea.decorators import shared_task
+
+from .base import BaseWebhookBackend
+from .webhook_security import validate_webhook_url
+
+
+class CustomBackendForm(forms.Form):
+    webhook_url = forms.URLField(required=True)
+
+    def __init__(self, *args, **kwargs):
+        config = kwargs.pop("config", None)
+
+        super().__init__(*args, **kwargs)
+        if config:
+            self.fields["webhook_url"].initial = config.get("webhook_url", "")
+
+    def get_config(self):
+        return {
+            "webhook_url": self.cleaned_data.get("webhook_url"),
+        }
+
+    def clean_webhook_url(self):
+        webhook_url = self.cleaned_data["webhook_url"]
+        try:
+            validate_webhook_url(webhook_url)
+        except ValueError as e:
+            raise forms.ValidationError(str(e)) from e
+        return webhook_url
+
+
+def _store_failure_info(service_config_id, exception, response=None):
+    """Store failure information in the MessagingServiceConfig with immediate_atomic"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+
+            config.last_failure_timestamp = timezone.now()
+            config.last_failure_error_type = type(exception).__name__
+            config.last_failure_error_message = str(exception)
+
+            # Handle requests-specific errors
+            if response is not None:
+                config.last_failure_status_code = response.status_code
+                config.last_failure_response_text = response.text[:2000]  # Limit response text size
+
+                # Check if response is JSON
+                try:
+                    json.loads(response.text)
+                    config.last_failure_is_json = True
+                except (json.JSONDecodeError, ValueError):
+                    config.last_failure_is_json = False
+            else:
+                # Non-HTTP errors
+                config.last_failure_status_code = None
+                config.last_failure_response_text = None
+                config.last_failure_is_json = None
+
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+def _store_success_info(service_config_id):
+    """Clear failure information on successful operation"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+            config.clear_failure_status()
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+@shared_task
+def custom_backend_send_test_message(webhook_url, project_name, display_name, service_config_id):
+    data = {
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "friendly_id": "TEST-1",
+        "project": 1,
+        "digest_order": 1,
+        "first_seen": "2024-01-10T08:15:00Z",
+        "last_seen": "2024-01-15T10:30:00Z",
+        "digested_event_count": 15,
+        "stored_event_count": 15,
+        "calculated_type": "ValueError",
+        "calculated_value": "invalid literal for int()",
+        "transaction": "/api/users/login",
+        "is_resolved": False,
+        "is_resolved_by_next_release": False,
+        "is_muted": False,
+        "title": "ValueError: invalid literal for int()",
+        "project_name": project_name,
+        "url": "https://bugsink.example.com/issues/497f6eca-6276-4993-bfeb-53cbbbba6f08/",
+        "alert_reason": "TEST",
+    }
+
+    try:
+        result = CustomBackend.safe_post(
+            webhook_url,
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, "response", None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+@shared_task
+def custom_backend_send_alert(
+    webhook_url, issue_id, state_description, alert_article, alert_reason, service_config_id, unmute_reason=None
+):
+    issue = Issue.objects.get(id=issue_id)
+    data = dict(IssueSerializer(issue).data)
+
+    # Add additional convenience fields
+    data["title"] = issue.title()
+    data["project_name"] = issue.project.name
+    data["url"] = get_settings().BASE_URL + issue.get_absolute_url()
+    data["alert_reason"] = alert_reason
+
+    if unmute_reason:
+        data["unmute_reason"] = unmute_reason
+
+    try:
+        result = CustomBackend.safe_post(
+            webhook_url,
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, "response", None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+class CustomBackend(BaseWebhookBackend):
+    def __init__(self, service_config):
+        self.service_config = service_config
+
+    @classmethod
+    def get_form_class(cls):
+        return CustomBackendForm
+
+    def send_test_message(self):
+        config = json.loads(self.service_config.config)
+        custom_backend_send_test_message.delay(
+            config["webhook_url"],
+            self.service_config.project.name,
+            self.service_config.display_name,
+            self.service_config.id,
+        )
+
+    def send_alert(self, issue_id, state_description, alert_article, alert_reason, **kwargs):
+        config = json.loads(self.service_config.config)
+        custom_backend_send_alert.delay(
+            config["webhook_url"],
+            issue_id,
+            state_description,
+            alert_article,
+            alert_reason,
+            self.service_config.id,
+            **kwargs,
+        )

--- a/alerts/service_backends/custom.py
+++ b/alerts/service_backends/custom.py
@@ -102,6 +102,7 @@ def custom_backend_send_test_message(webhook_url, project_name, display_name, se
         "calculated_value": "invalid literal for int()",
         "transaction": "/api/users/login",
         "is_resolved": False,
+        "is_resolved_unconditionally": False,
         "is_resolved_by_next_release": False,
         "is_muted": False,
         "title": "ValueError: invalid literal for int()",
@@ -133,6 +134,8 @@ def custom_backend_send_alert(
     webhook_url, issue_id, state_description, alert_article, alert_reason, service_config_id, unmute_reason=None
 ):
     issue = Issue.objects.get(id=issue_id)
+
+    # Deliberately mirror the canonical issue API; a test keeps the test-message fields aligned with this payload.
     data = dict(IssueSerializer(issue).data)
 
     # Add additional convenience fields

--- a/alerts/service_backends/custom.py
+++ b/alerts/service_backends/custom.py
@@ -15,7 +15,7 @@ from .webhook_security import validate_webhook_url
 
 
 class CustomBackendForm(forms.Form):
-    webhook_url = forms.URLField(required=True)
+    webhook_url = forms.URLField(required=True, assume_scheme="https")
 
     def __init__(self, *args, **kwargs):
         config = kwargs.pop("config", None)

--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -856,6 +856,33 @@ class TestCustomBackendErrorHandling(DjangoTestCase):
         self.config.refresh_from_db()
         self.assertIsNone(self.config.last_failure_timestamp)
 
+    @patch("alerts.service_backends.base.BaseWebhookBackend.safe_post")
+    def test_custom_test_message_fields_match_alert_message(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        custom_backend_send_test_message(
+            "https://hooks.example.com/test",
+            "Test project",
+            "Test Custom",
+            self.config.id,
+        )
+        test_payload = json.loads(mock_post.call_args.kwargs["data"])
+
+        issue, _ = get_or_create_issue(project=self.project)
+        custom_backend_send_alert(
+            "https://hooks.example.com/test",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+        )
+        alert_payload = json.loads(mock_post.call_args.kwargs["data"])
+
+        self.assertEqual(set(test_payload), set(alert_payload))
+
     def test_has_recent_failure_method(self):
         # Initially no failure
         self.assertFalse(self.config.has_recent_failure())

--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -29,6 +29,7 @@ from .service_backends.telegram import (
     telegram_backend_send_alert,
     telegram_backend_send_test_message,
 )
+from .service_backends.custom import CustomBackendForm, custom_backend_send_test_message, custom_backend_send_alert
 from .service_backends.webhook_security import validate_webhook_url
 from .tasks import send_new_issue_alert, send_regression_alert, send_unmute_alert, _get_users_for_email_alert
 from .views import DEBUG_CONTEXTS
@@ -706,6 +707,170 @@ class TestTelegramBackend(DjangoTestCase):
         self.assertNotIn("message_thread_id", payload)
 
 
+class TestCustomBackendErrorHandling(DjangoTestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test project")
+        self.config = MessagingServiceConfig.objects.create(
+            project=self.project,
+            display_name="Test Custom",
+            kind="custom",
+            config=json.dumps({"webhook_url": "https://hooks.example.com/test"}),
+        )
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_custom_test_message_success_clears_failure_status(self, mock_post):
+        # Set up existing failure status
+        self.config.last_failure_timestamp = timezone.now()
+        self.config.last_failure_status_code = 500
+        self.config.last_failure_response_text = "Server Error"
+        self.config.save()
+
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        # Send test message
+        custom_backend_send_test_message(
+            "https://hooks.example.com/test",
+            "Test project",
+            "Test Custom",
+            self.config.id
+        )
+
+        # Verify failure status was cleared
+        self.config.refresh_from_db()
+        self.assertIsNone(self.config.last_failure_timestamp)
+        self.assertIsNone(self.config.last_failure_status_code)
+        self.assertIsNone(self.config.last_failure_response_text)
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_custom_test_message_http_error_stores_failure(self, mock_post):
+        # Mock HTTP error response
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = '{"error": "not_found"}'
+
+        # Create the HTTPError with response attached
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        mock_post.return_value = mock_response
+
+        # Send test message
+        custom_backend_send_test_message(
+            "https://hooks.example.com/test",
+            "Test project",
+            "Test Custom",
+            self.config.id
+        )
+
+        # Verify failure status was stored
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertEqual(self.config.last_failure_status_code, 404)
+        self.assertEqual(self.config.last_failure_response_text, '{"error": "not_found"}')
+        self.assertTrue(self.config.last_failure_is_json)
+        self.assertEqual(self.config.last_failure_error_type, "HTTPError")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_custom_test_message_non_json_error_stores_failure(self, mock_post):
+        # Mock HTTP error response with non-JSON text
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = 'Internal Server Error'
+
+        # Create the HTTPError with response attached
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        mock_post.return_value = mock_response
+
+        # Send test message
+        custom_backend_send_test_message(
+            "https://hooks.example.com/test",
+            "Test project",
+            "Test Custom",
+            self.config.id
+        )
+
+        # Verify failure status was stored
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertEqual(self.config.last_failure_status_code, 500)
+        self.assertEqual(self.config.last_failure_response_text, 'Internal Server Error')
+        self.assertFalse(self.config.last_failure_is_json)
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_custom_test_message_connection_error_stores_failure(self, mock_post):
+        # Mock connection error
+        mock_post.side_effect = requests.ConnectionError("Connection failed")
+
+        # Send test message
+        custom_backend_send_test_message(
+            "https://hooks.example.com/test",
+            "Test project",
+            "Test Custom",
+            self.config.id
+        )
+
+        # Verify failure status was stored
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertIsNone(self.config.last_failure_status_code)  # No HTTP response
+        self.assertIsNone(self.config.last_failure_response_text)
+        self.assertIsNone(self.config.last_failure_is_json)
+        self.assertEqual(self.config.last_failure_error_type, "ConnectionError")
+        self.assertEqual(self.config.last_failure_error_message, "Connection failed")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_custom_alert_message_success_clears_failure_status(self, mock_post):
+        # Set up existing failure status
+        self.config.last_failure_timestamp = timezone.now()
+        self.config.last_failure_status_code = 500
+        self.config.save()
+
+        # Create issue
+        issue, _ = get_or_create_issue(project=self.project)
+
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        # Send alert message
+        custom_backend_send_alert(
+            "https://hooks.example.com/test",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id
+        )
+
+        # Verify failure status was cleared
+        self.config.refresh_from_db()
+        self.assertIsNone(self.config.last_failure_timestamp)
+
+    def test_has_recent_failure_method(self):
+        # Initially no failure
+        self.assertFalse(self.config.has_recent_failure())
+
+        # Set failure
+        self.config.last_failure_timestamp = timezone.now()
+        self.config.save()
+        self.assertTrue(self.config.has_recent_failure())
+
+        # Clear failure
+        self.config.clear_failure_status()
+        self.config.save()
+        self.assertFalse(self.config.has_recent_failure())
+
+
 class TestWebhookSecurityValidation(DjangoTestCase):
     def test_safe_post_does_not_re_resolve_after_validation(self):
         original_getaddrinfo = socket.getaddrinfo
@@ -935,3 +1100,9 @@ class TestWebhookConfigForms(DjangoTestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("This field is required.", form.errors["bot_token"][0])
+
+    def test_custom_form_rejects_blocked_target(self):
+        form = CustomBackendForm(data={"webhook_url": "http://10.0.0.42/hooks/test"})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("non-global IP address", form.errors["webhook_url"][0])


### PR DESCRIPTION
Implements #429 

Adds an option to configure alert webhooks with an arbitrary destination.

For the payload, I decided to mirror what the API returns when fetching issue information + I added some additional fields for convenience, like `url`, `title`, and so on. The structure follows how the other backends are implemented.

Tested locally with the test message:
```json
{
  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
  "friendly_id": "TEST-1",
  "project": 1,
  "digest_order": 1,
  "first_seen": "2024-01-10T08:15:00Z",
  "last_seen": "2024-01-15T10:30:00Z",
  "digested_event_count": 15,
  "stored_event_count": 15,
  "calculated_type": "ValueError",
  "calculated_value": "invalid literal for int()",
  "transaction": "/api/users/login",
  "is_resolved": false,
  "is_resolved_by_next_release": false,
  "is_muted": false,
  "title": "ValueError: invalid literal for int()",
  "project_name": "Kanto Adventures",
  "url": "https://bugsink.example.com/issues/497f6eca-6276-4993-bfeb-53cbbbba6f08/",
  "alert_reason": "TEST"
}
```