### PR TITLE
Envelope parser / event ingest: 2 minor fixes

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -228,7 +228,7 @@ class Event(models.Model):
                 data=json.dumps(parsed_data) if write_storage is None else "",
                 storage_backend=None if write_storage is None else write_storage.name,
 
-                timestamp=parse_timestamp(parsed_data["timestamp"]),
+                timestamp=parse_timestamp(parsed_data.get("timestamp", event_metadata["ingested_at"])),
                 platform=parsed_data["platform"][:64],
 
                 level=maybe_empty(parsed_data.get("level", "")),

--- a/ingest/parsers.py
+++ b/ingest/parsers.py
@@ -141,7 +141,12 @@ class StreamingEnvelopeParser:
                 raise ParseError("EOF when reading headers; what is this a header for then?")
 
         try:
-            return json.loads(header_stream_value.decode("utf-8"))  # points 1, 2
+            header = header_stream_value.decode("utf-8")  # point 1
+        except UnicodeDecodeError as e:
+            raise ParseError("Header not UTF-8") from e
+
+        try:
+            return json.loads(header)  # point 2
         except json.JSONDecodeError as e:
             raise ParseError("Header not JSON") from e
 

--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -1603,6 +1603,13 @@ class TestParser(RegularTestCase):
             header, item = next(items)
         self.assertEqual("Header not JSON", str(e.exception))
 
+    def test_non_utf8_header(self):
+        parser = StreamingEnvelopeParser(io.BytesIO(b"\x8b"))
+
+        with self.assertRaises(ParseError) as e:
+            parser.get_envelope_headers()
+        self.assertEqual("Header not UTF-8", str(e.exception))
+
     def test_eof_after_envelope_headers(self):
         # whether this is valid or not: not entirely clear from the docs. It won't matter in practice, of course
         # (because nothing interesting is contained)

--- a/ingest/views.py
+++ b/ingest/views.py
@@ -710,7 +710,11 @@ class IngestEventAPIView(BaseIngestAPIView):
 
         performance_logger.info("ingested event with %s bytes", len(event_data_bytes))
 
-        event_data = json.loads(event_data_bytes)
+        try:
+            event_data = json.loads(event_data_bytes)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            raise ParseError("invalid JSON in event: %s" % e)
+
         if "event_id" not in event_data:
             event_data["event_id"] = uuid.uuid4().hex
         filename = get_filename_for_event_id(ingestion_id)


### PR DESCRIPTION
* Missing timestamp in event_data: don't crash
* Don't crash on non-utf8 envelope headers