### PR TITLE
Plain Resolve & Resolve-by-current (when observations exist)

### DIFF
--- a/issues/api_views.py
+++ b/issues/api_views.py
@@ -212,9 +212,6 @@ class IssueViewSet(AtomicRequestMixin, viewsets.ReadOnlyModelViewSet):
             raise ValidationError({"detail": "Project has no releases."})
 
         latest_release = issue.project.get_latest_release()
-        if latest_release.version + "\n" in issue.events_at:
-            raise ValidationError({"detail": "Issue has already occurred in the latest release."})
-
         return self._apply_issue_action(issue, "resolved_release:" + latest_release.version)
 
     @extend_schema(

--- a/issues/migrations/0027_issue_is_resolved_unconditionally.py
+++ b/issues/migrations/0027_issue_is_resolved_unconditionally.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("issues", "0026_alter_turningpoint_kind"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issue",
+            name="is_resolved_unconditionally",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/issues/migrations/0028_migrate_empty_fixed_at.py
+++ b/issues/migrations/0028_migrate_empty_fixed_at.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+
+def migrate_empty_fixed_at(apps, schema_editor):
+    Issue = apps.get_model("issues", "Issue")
+
+    for issue in Issue.objects.filter(fixed_at__contains="\n"):
+        fixed_at = issue.fixed_at.split("\n")[:-1]
+        if "" not in fixed_at:
+            continue
+
+        issue.fixed_at = "".join(release + "\n" for release in fixed_at if release != "")
+        if issue.is_resolved and not issue.is_resolved_by_next_release:
+            issue.is_resolved_unconditionally = True
+        issue.save(update_fields=["fixed_at", "is_resolved_unconditionally"])
+
+
+def unmigrate_empty_fixed_at(apps, schema_editor):
+    Issue = apps.get_model("issues", "Issue")
+
+    for issue in Issue.objects.filter(is_resolved_unconditionally=True):
+        fixed_at = issue.fixed_at.split("\n")[:-1]
+        if "" not in fixed_at:
+            fixed_at.append("")
+            issue.fixed_at = "".join(release + "\n" for release in fixed_at)
+            issue.save(update_fields=["fixed_at"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("issues", "0027_issue_is_resolved_unconditionally"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_empty_fixed_at, unmigrate_empty_fixed_at),
+    ]

--- a/issues/models.py
+++ b/issues/models.py
@@ -539,12 +539,7 @@ def is_valid_issue_action(action, issue):
         # any other action is illegal on resolved issues
         return False
 
-    if action.startswith("resolved_release:"):
-        release_version = action.split(":", 1)[1]
-        if release_version + "\n" in issue.events_at:
-            return False
-
-    elif action.startswith("mute"):
+    if action.startswith("mute"):
         if issue.is_muted:
             return False
 
@@ -570,11 +565,7 @@ def q_for_invalid_issue_action(action):
 
     illegal_conditions = Q(is_resolved=True)  # any other action is illegal on resolved issues
 
-    if action.startswith("resolved_release:"):
-        release_version = action.split(":", 1)[1]
-        illegal_conditions = illegal_conditions | Q(events_at__contains=release_version + "\n")
-
-    elif action.startswith("mute"):
+    if action.startswith("mute"):
         illegal_conditions = illegal_conditions | Q(is_muted=True)
 
     elif action == "unmute":

--- a/issues/models.py
+++ b/issues/models.py
@@ -63,6 +63,7 @@ class Issue(models.Model):
     # what does this mean for the release-based use cases? it means what you filter on.
     # it also simply means: it was "marked as resolved" after the last regression (if any)
     is_resolved = models.BooleanField(default=False)
+    is_resolved_unconditionally = models.BooleanField(default=False)
     is_resolved_by_next_release = models.BooleanField(default=False)
 
     fixed_at = models.TextField(blank=True, null=False, default='')  # line-separated list
@@ -283,7 +284,8 @@ class IssueStateManager(object):
     @staticmethod
     def resolve(issue):
         issue.is_resolved = True
-        issue.add_fixed_at("")  # i.e. fixed in the no-release-info-available release
+        issue.is_resolved_unconditionally = True
+        issue.is_resolved_by_next_release = False
 
         # an issue cannot be both resolved and muted; muted means "the problem persists but don't tell me about it
         # (or maybe unless some specific condition happens)" and resolved means "the problem is gone". Hence, resolving
@@ -296,6 +298,8 @@ class IssueStateManager(object):
     def resolve_by_latest(issue):
         # NOTE: currently unused; we may soon reintroduce it though so I left it in.
         issue.is_resolved = True
+        issue.is_resolved_unconditionally = False
+        issue.is_resolved_by_next_release = False
         issue.add_fixed_at(issue.project.get_latest_release().version)
         IssueStateManager.unmute(issue)  # as in IssueStateManager.resolve()
 
@@ -303,18 +307,22 @@ class IssueStateManager(object):
     def resolve_by_release(issue, release_version):
         # release_version: str
         issue.is_resolved = True
+        issue.is_resolved_unconditionally = False
+        issue.is_resolved_by_next_release = False
         issue.add_fixed_at(release_version)
         IssueStateManager.unmute(issue)  # as in IssueStateManager.resolve()
 
     @staticmethod
     def resolve_by_next(issue):
         issue.is_resolved = True
+        issue.is_resolved_unconditionally = False
         issue.is_resolved_by_next_release = True
         IssueStateManager.unmute(issue)  # as in IssueStateManager.resolve()
 
     @staticmethod
     def reopen(issue):
         issue.is_resolved = False
+        issue.is_resolved_unconditionally = False
         issue.is_resolved_by_next_release = False  # clear related is_resolved_xxx state too
 
         # we don't touch `fixed_at`. The meaning of that field is "reports came in about fixes at these points in time",
@@ -414,20 +422,23 @@ class IssueQuerysetStateManager(object):
     def _resolve_at(issue_qs, release_version):
         filter_qs_for_fixed_at(issue_qs, release_version).update(
             is_resolved=True,
+            is_resolved_unconditionally=False,
+            is_resolved_by_next_release=False,
         )
-        exclude_qs_for_fixed_at(issue_qs, "").update(
+        exclude_qs_for_fixed_at(issue_qs, release_version).update(
             is_resolved=True,
-            fixed_at=Concat(F("fixed_at"), Value(release_version + "\n")),
-        )
-
-        # release_version: str
-        issue_qs.update(
+            is_resolved_unconditionally=False,
+            is_resolved_by_next_release=False,
             fixed_at=Concat(F("fixed_at"), Value(release_version + "\n")),
         )
 
     @staticmethod
     def resolve(issue_qs):
-        IssueQuerysetStateManager._resolve_at(issue_qs, "")  # i.e. fixed in the no-release-info-available release
+        issue_qs.update(
+            is_resolved=True,
+            is_resolved_unconditionally=True,
+            is_resolved_by_next_release=False,
+        )
 
         # an issue cannot be both resolved and muted; muted means "the problem persists but don't tell me about it
         # (or maybe unless some specific condition happens)" and resolved means "the problem is gone". Hence, resolving
@@ -458,6 +469,7 @@ class IssueQuerysetStateManager(object):
     def resolve_by_next(issue_qs):
         issue_qs.update(
             is_resolved=True,
+            is_resolved_unconditionally=False,
             is_resolved_by_next_release=True,
         )
 
@@ -468,6 +480,7 @@ class IssueQuerysetStateManager(object):
         # Currently unused by the UI; implemented for completeness because generic issue-action plumbing supports it.
         issue_qs.update(
             is_resolved=False,
+            is_resolved_unconditionally=False,
             is_resolved_by_next_release=False,
         )
         IssueQuerysetStateManager.unmute(issue_qs)

--- a/issues/regressions.py
+++ b/issues/regressions.py
@@ -18,10 +18,10 @@ def is_regression(sorted_releases, fixed_at, events_at, current_event_at):
     marked_as_resolved = False
 
     for r in sorted_releases:
-        if r in events_at:
-            marked_as_resolved = False
-        elif r in fixed_at:
+        if r in fixed_at:
             marked_as_resolved = True
+        elif r in events_at:
+            marked_as_resolved = False
 
         if current_event_at == r:
             return marked_as_resolved
@@ -76,11 +76,11 @@ def is_regression_2(sorted_releases, fixed_at, events_at, current_event_at):
     marked_as_resolved = False
 
     for r in sorted_releases:
-        if r in events_at:
-            marked_as_resolved = False
-        elif r in fixed_at:
+        if r in fixed_at:
             marked_as_resolved = True
             fixed_at.remove(r)
+        elif r in events_at:
+            marked_as_resolved = False
 
         if current_event_at == r:
             return marked_as_resolved, len(fixed_at) > 0

--- a/issues/regressions.py
+++ b/issues/regressions.py
@@ -48,6 +48,9 @@ def issue_is_regression(issue, current_event_at):
         # Which means that seeing new events does not imply a regression, because that future hasn't arrived yet.
         return False
 
+    if issue.is_resolved_unconditionally:
+        return True
+
     if not issue.project.has_releases:
         # the simple case: no releases means that seeing new events implies a regression if the issue.is_resolved, which
         # is True given the first guard clause.

--- a/issues/serializers.py
+++ b/issues/serializers.py
@@ -36,6 +36,7 @@ class IssueSerializer(UTCModelSerializer):
             # "last_frame_module",
             # "last_frame_function",
             "is_resolved",
+            "is_resolved_unconditionally",
             "is_resolved_by_next_release",
             # "fixed_at",  too "raw"? i.e. too implementation-tied?
             # "events_at",  too "raw"? i.e. too implementation-tied?

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -38,11 +38,7 @@
                     {# note that we can depend on get_latest_release being available, because we're in the 'project.has_releases' branch #}
                     <div class="dropdown-content-right flex-col pl-2">
                         <button name="action" value="resolved_next" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">{% translate "Resolved in next release" %}</button>
-                        {% if not issue.occurs_in_last_release %}
-                            <button name="action" value="resolved_release:{{ issue.project.get_latest_release.version }}" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">Resolved in latest ({{ issue.project.get_latest_release.get_short_version }})</button>
-                        {% else %}
-                            <button name="action" value="resolved_release:{{ issue.project.get_latest_release.version }}" disabled class="block self-stretch font-bold text-slate-300 dark:text-slate-600 border-slate-200 dark:border-slate-700 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 text-left whitespace-nowrap">Resolved in latest ({{ issue.project.get_latest_release.get_short_version }})</button>
-                        {% endif %}
+                        <button name="action" value="resolved_release:{{ issue.project.get_latest_release.version }}" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">Resolved in latest ({{ issue.project.get_latest_release.get_short_version }})</button>
 
                     </div>
                 </div>

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -30,15 +30,14 @@
             {% spaceless %}{# needed to avoid whitespace between the looks-like-one-buttons #}
 
             {% if issue.project.has_releases %}
-                {# 'by next' is shown even if 'by current' is also shown: just because you haven't seen 'by current' doesn't mean it's actually already solved; and in fact we show this option first precisely because we can always show it #}
-                <button class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-s-md" name="action" value="resolved_next">{% translate "Resolved in next release" %}</button>
+                <button class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-s-md" name="action" value="resolve">{% translate "Resolve" %}</button>
 
                 <div class="dropdown">
                     <button disabled {# disabled b/c clicking the dropdown does nothing - we have hover for that #} class="font-bold text-slate-800 dark:text-slate-100 fill-slate-800 dark:fill-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 border-r-2 border-t-2 border-b-2 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 rounded-e-md"><svg xmlns="http://www.w3.org/2000/svg" fill="full" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 inline"><path d="M6.5,8.5l6,7l6-7H6.5z"/></svg></button>
 
                     {# note that we can depend on get_latest_release being available, because we're in the 'project.has_releases' branch #}
                     <div class="dropdown-content-right flex-col pl-2">
-
+                        <button name="action" value="resolved_next" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">{% translate "Resolved in next release" %}</button>
                         {% if not issue.occurs_in_last_release %}
                             <button name="action" value="resolved_release:{{ issue.project.get_latest_release.version }}" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">Resolved in latest ({{ issue.project.get_latest_release.get_short_version }})</button>
                         {% else %}

--- a/issues/templates/issues/issue_list.html
+++ b/issues/templates/issues/issue_list.html
@@ -84,12 +84,12 @@
 
                     {% spaceless %}{# needed to avoid whitespace between the looks-like-one-buttons #}
                     {% if project.has_releases %}
-                        <button disabled class="font-bold text-slate-300 dark:text-slate-600 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 rounded-s-md" name="action" value="resolved_next">{% translate "Resolved in next release" %}</button>
+                        <button disabled class="font-bold text-slate-300 dark:text-slate-600 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 rounded-s-md" name="action" value="resolve">{% translate "Resolve" %}</button>
 
                         <button disabled class="font-bold text-slate-300 dark:text-slate-600 fill-slate-300 dark:fill-slate-600 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-r-2 border-t-2 border-b-2 rounded-e-md"><svg xmlns="http://www.w3.org/2000/svg" fill="full" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 inline"><path d="M6.5,8.5l6,7l6-7H6.5z"/></svg></button>
                         {# we just hide the whole dropdown; this is the easiest implementation of not-showing the dropdown #}
                     {% else %}
-                        <button disabled class="font-bold text-slate-300 dark:text-slate-600 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 rounded-md" name="action" value="resolved">{% translate "Resolve" %}</button>
+                        <button disabled class="font-bold text-slate-300 dark:text-slate-600 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 rounded-md" name="action" value="resolve">{% translate "Resolve" %}</button>
                     {% endif %}
                     {% endspaceless %}
 
@@ -97,15 +97,14 @@
                     {% spaceless %}{# needed to avoid whitespace between the looks-like-one-buttons #}
 
                     {% if project.has_releases %}
-                        {# 'by next' is shown even if 'by current' is also shown: just because you haven't seen 'by current' doesn't mean it's actually already solved; and in fact we show this option first precisely because we can always show it #}
-                        <button class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-s-md" name="action" value="resolved_next">Resolved in next release</button>
+                        <button class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-s-md" name="action" value="resolve">{% translate "Resolve" %}</button>
 
                         <div class="dropdown">
                             <button disabled {# disabled b/c clicking the dropdown does nothing - we have hover for that #} class="font-bold text-slate-800 dark:text-slate-100 fill-slate-800 dark:fill-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 border-r-2 border-t-2 border-b-2 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 rounded-e-md"><svg xmlns="http://www.w3.org/2000/svg" fill="full" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 inline"><path d="M6.5,8.5l6,7l6-7H6.5z"/></svg></button>
 
                             {# note that we can depend on get_latest_release being available, because we're in the 'project.has_releases' branch #}
                             <div class="dropdown-content-right flex-col pl-2">
-
+                                <button name="action" value="resolved_next" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">{% translate "Resolved in next release" %}</button>
                                 {# note that an if-statement ("issue.occurs_in_last_release") is missing here, because we're not on the level of a single issue #}
                                 {# handling of that question (but per-issue, and after-click) is done in views.py, _q_for_invalid_for_action()  #}
                                 <button name="action" value="resolved_release:{{ project.get_latest_release.version }}" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">Resolved in latest ({{ project.get_latest_release.get_short_version }})</button>

--- a/issues/templates/issues/issue_list.html
+++ b/issues/templates/issues/issue_list.html
@@ -105,8 +105,6 @@
                             {# note that we can depend on get_latest_release being available, because we're in the 'project.has_releases' branch #}
                             <div class="dropdown-content-right flex-col pl-2">
                                 <button name="action" value="resolved_next" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">{% translate "Resolved in next release" %}</button>
-                                {# note that an if-statement ("issue.occurs_in_last_release") is missing here, because we're not on the level of a single issue #}
-                                {# handling of that question (but per-issue, and after-click) is done in views.py, _q_for_invalid_for_action()  #}
                                 <button name="action" value="resolved_release:{{ project.get_latest_release.version }}" class="block self-stretch font-bold text-slate-500 dark:text-slate-300 border-slate-300 dark:border-slate-600 pl-4 pr-4 pb-2 pt-2 border-l-2 border-r-2 border-b-2 bg-white dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800 active:ring-3 text-left whitespace-nowrap">Resolved in latest ({{ project.get_latest_release.get_short_version }})</button>
                             </div>
                         </div>

--- a/issues/test_api.py
+++ b/issues/test_api.py
@@ -137,6 +137,19 @@ class IssueApiTests(TransactionTestCase):
         self.assertFalse(self.issue0.is_resolved_unconditionally)
         self.assertEqual(self.issue0.fixed_at, "1.0.0\n")
 
+    def test_resolve_latest_allows_existing_occurrence(self):
+        create_release_if_needed(self.project, "1.0.0", timezone.now())
+        self.issue0.events_at = "1.0.0\n"
+        self.issue0.save()
+
+        response = self.client.post(reverse("api:issue-resolve-latest", args=[self.issue0.id]))
+        self.assertEqual(response.status_code, 200)
+
+        self.issue0.refresh_from_db()
+        self.assertTrue(self.issue0.is_resolved)
+        self.assertFalse(self.issue0.is_resolved_unconditionally)
+        self.assertEqual(self.issue0.fixed_at, "1.0.0\n")
+
     def test_resolve_latest_requires_releases(self):
         response = self.client.post(reverse("api:issue-resolve-latest", args=[self.issue0.id]))
         self.assertEqual(response.status_code, 400)

--- a/issues/test_api.py
+++ b/issues/test_api.py
@@ -109,7 +109,10 @@ class IssueApiTests(TransactionTestCase):
 
         self.issue0.refresh_from_db()
         self.assertTrue(self.issue0.is_resolved)
+        self.assertTrue(self.issue0.is_resolved_unconditionally)
+        self.assertEqual(self.issue0.fixed_at, "")
         self.assertEqual(response.json()["is_resolved"], True)
+        self.assertEqual(response.json()["is_resolved_unconditionally"], True)
 
         turningpoint = TurningPoint.objects.get(issue=self.issue0)
         self.assertEqual(turningpoint.kind, TurningPointKind.RESOLVED)
@@ -131,6 +134,7 @@ class IssueApiTests(TransactionTestCase):
 
         self.issue0.refresh_from_db()
         self.assertTrue(self.issue0.is_resolved)
+        self.assertFalse(self.issue0.is_resolved_unconditionally)
         self.assertEqual(self.issue0.fixed_at, "1.0.0\n")
 
     def test_resolve_latest_requires_releases(self):
@@ -146,8 +150,10 @@ class IssueApiTests(TransactionTestCase):
 
         self.issue0.refresh_from_db()
         self.assertFalse(self.issue0.is_resolved)
+        self.assertFalse(self.issue0.is_resolved_unconditionally)
         self.assertFalse(self.issue0.is_resolved_by_next_release)
         self.assertEqual(response.json()["is_resolved"], False)
+        self.assertEqual(response.json()["is_resolved_unconditionally"], False)
         self.assertEqual(response.json()["is_resolved_by_next_release"], False)
 
         turningpoint = TurningPoint.objects.get(issue=self.issue0)

--- a/issues/tests.py
+++ b/issues/tests.py
@@ -115,10 +115,10 @@ class RegressionUtilTestCase(RegularTestCase):
             events_at=["a"],
             current_event_at="b"))
 
-    def test_observations_override_marked_resolutions(self):
-        # if an issue has been marked as resolved but has also (presumably later on) been seen in reality to not have
-        # been resolved, it is not resolved by that release. Hence, re-occurrence is not a (new) regression.
-        self.assertFalse(is_regression(
+    def test_marked_resolutions_override_observations(self):
+        # Marking an issue as resolved in a release where it has already been seen means "resolved as of now".
+        # A later event in that same release is therefore a regression.
+        self.assertTrue(is_regression(
             self.releases,
             fixed_at=["c"],
             events_at=["c"],
@@ -265,6 +265,25 @@ class RegressionIssueTestCase(DjangoTestCase):
         self.assertFalse(issue_is_regression(fresh(issue), "1.0.0"))
         self.assertFalse(issue_is_regression(fresh(issue), "2.0.0"))
 
+    def test_issue_is_regression_with_releases_resolve_by_latest_after_observation(self):
+        project = Project.objects.create()
+        timestamp = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+        create_release_if_needed(fresh(project), "1.0.0", timestamp)
+        create_release_if_needed(fresh(project), "2.0.0", timestamp)
+
+        issue = Issue.objects.create(
+            project=project,
+            events_at="2.0.0\n",
+            **denormalized_issue_fields(),
+        )
+
+        IssueStateManager.resolve_by_latest(issue)
+        issue.save()
+
+        self.assertFalse(issue_is_regression(fresh(issue), "1.0.0"))
+        self.assertTrue(issue_is_regression(fresh(issue), "2.0.0"))
+
     def test_issue_is_regression_after_plain_resolve_on_release_project(self):
         project = Project.objects.create()
         timestamp = datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -274,14 +293,21 @@ class RegressionIssueTestCase(DjangoTestCase):
 
         issue = Issue.objects.create(
             project=project,
-            events_at="1.0.0\n1.1.0\n",
+            events_at="1.0.0\n",
             **denormalized_issue_fields(),
         )
 
+        # Seen at 1.0, resolved at 1.0.
+        IssueStateManager.resolve_by_release(issue, "1.0.0")
+        issue.save()
+
+        # Seen at 1.1, then resolved without pinning to a release.
+        IssueStateManager.reopen(issue)
+        issue.events_at += "1.1.0\n"
         IssueStateManager.resolve(issue)
         issue.save()
 
-        self.assertEqual(fresh(issue).fixed_at, "")
+        self.assertEqual(fresh(issue).fixed_at, "1.0.0\n")
         self.assertTrue(fresh(issue).is_resolved_unconditionally)
         self.assertTrue(issue_is_regression(fresh(issue), "1.0.0"))
         self.assertTrue(issue_is_regression(fresh(issue), "1.1.0"))

--- a/issues/tests.py
+++ b/issues/tests.py
@@ -265,6 +265,27 @@ class RegressionIssueTestCase(DjangoTestCase):
         self.assertFalse(issue_is_regression(fresh(issue), "1.0.0"))
         self.assertFalse(issue_is_regression(fresh(issue), "2.0.0"))
 
+    def test_issue_is_regression_after_plain_resolve_on_release_project(self):
+        project = Project.objects.create()
+        timestamp = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+        create_release_if_needed(fresh(project), "1.0.0", timestamp)
+        create_release_if_needed(fresh(project), "1.1.0", timestamp)
+
+        issue = Issue.objects.create(
+            project=project,
+            events_at="1.0.0\n1.1.0\n",
+            **denormalized_issue_fields(),
+        )
+
+        IssueStateManager.resolve(issue)
+        issue.save()
+
+        self.assertEqual(fresh(issue).fixed_at, "")
+        self.assertTrue(fresh(issue).is_resolved_unconditionally)
+        self.assertTrue(issue_is_regression(fresh(issue), "1.0.0"))
+        self.assertTrue(issue_is_regression(fresh(issue), "1.1.0"))
+
     def test_issue_is_regression_with_releases_resolve_by_next(self):
         project = Project.objects.create()
         timestamp = datetime(2020, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
This MR introduces 2 new ways of resolving:

First, it makes plain Resolve available for projects that have releases. In that mode, a later event is a regression regardless of which release the event reports. This is useful for out-of-code fixes, or when pinpointing the exact release has too little value.

It also introduces resolving in release X while observations already exist for release X. That was previously rejected because a release cannot literally have fixed an issue that already occurred there, but the practical workflow is still useful. 