### PR TITLE
Add configurable generic outgoing-webhook alert backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## ..... (unreleased)
 
+### Alerting
+
+Add a generic `Webhook` alert backend that POSTs JSON to any URL. This makes Bugsink alerts usable with systems that
+accept generic webhooks (e.g. Matrix via matrix-hookshot) without a product-specific backend. By default it sends a
+neutral, self-describing payload (a human-readable `text` plus a structured `issue` object); an optional body template
+(stdlib `string.Template`, with placeholders expanding to JSON-encoded values) lets users shape the request body to
+match any receiver's schema. See #429.
+
 ### Backwards incompatible changes
 
 Fail to start when `PID_FILE` is configured to be in a directory not owned by the process running gunicorn/snappea

--- a/alerts/models.py
+++ b/alerts/models.py
@@ -4,6 +4,7 @@ from projects.models import Project
 from .service_backends.slack import SlackBackend
 from .service_backends.mattermost import MattermostBackend
 from .service_backends.discord import DiscordBackend
+from .service_backends.webhook import WebhookBackend
 
 
 def get_alert_service_kind_choices():
@@ -13,6 +14,7 @@ def get_alert_service_kind_choices():
         ("discord", "Discord"),
         ("mattermost", "Mattermost"),
         ("slack", "Slack"),
+        ("webhook", "Webhook (generic)"),
     ]
 
 
@@ -23,6 +25,8 @@ def get_alert_service_backend_class(kind):
         return MattermostBackend
     if kind == "slack":
         return SlackBackend
+    if kind == "webhook":
+        return WebhookBackend
     raise ValueError(f"Unknown backend kind: {kind}")
 
 

--- a/alerts/service_backends/webhook.py
+++ b/alerts/service_backends/webhook.py
@@ -1,0 +1,292 @@
+"""Generic (neutral) outgoing-webhook alert backend.
+
+POSTs JSON (``Content-Type: application/json``) to any URL, so Bugsink alerts
+can reach systems without a product-specific backend (e.g. Matrix via
+matrix-hookshot, n8n, home-grown receivers).
+
+Without a ``body_template`` a neutral default payload is sent. With one, the
+body is rendered via stdlib ``string.Template`` (``safe_substitute``) -- no
+logic/eval, minimal attack surface. Every placeholder expands to a JSON-encoded
+value, so the rule is: put a bare ``$var`` where a JSON value belongs and the
+result is always valid JSON, e.g. ``{"text": $summary, "url": $issue_url}``.
+
+Placeholders: ``$summary``, ``$issue_title``, ``$issue_url``, ``$project``,
+``$alert_reason``, ``$issue_id``, ``$issue_friendly_id``, ``$unmute_reason``.
+Templates are validated (rendered sample must parse as JSON) at save time.
+"""
+
+import json
+import string
+import requests
+from django.utils import timezone
+
+from django import forms
+from django.template.defaultfilters import truncatechars
+
+from snappea.decorators import shared_task
+from bugsink.app_settings import get_settings
+from bugsink.transaction import immediate_atomic
+
+from issues.models import Issue
+from .base import BaseWebhookBackend
+from .webhook_security import validate_webhook_url
+
+
+def _build_raw_context(summary, issue_title, issue_url, project, alert_reason, issue_id, issue_friendly_id,
+                       unmute_reason):
+    """Single definition of the template placeholder key set (shared by the config-time
+    JSON validation, the alert task and the test-message task, so they can't drift)."""
+    return {
+        "summary": summary,
+        "issue_title": issue_title,
+        "issue_url": issue_url,
+        "project": project,
+        "alert_reason": alert_reason,
+        "issue_id": issue_id,
+        "issue_friendly_id": issue_friendly_id,
+        "unmute_reason": unmute_reason,
+    }
+
+
+def _sample_raw_context():
+    """Representative values for every placeholder, used to validate a template at save time."""
+    return _build_raw_context(
+        summary="NEW issue: Example error - " + get_settings().BASE_URL,
+        issue_title="Example error",
+        issue_url=get_settings().BASE_URL,
+        project="Example project",
+        alert_reason="NEW",
+        issue_id="1",
+        issue_friendly_id="PROJ-42",
+        unmute_reason=None,
+    )
+
+
+def _render_body(body_template, raw_context, default_data):
+    """Render the request body.
+
+    With a (non-empty) body_template: substitute JSON-encoded values into the
+    user's string.Template. Otherwise: serialize the default payload.
+    """
+    if body_template:
+        context = {key: json.dumps(value) for key, value in raw_context.items()}
+        return string.Template(body_template).safe_substitute(context)
+    return json.dumps(default_data)
+
+
+class GenericWebhookConfigForm(forms.Form):
+    webhook_url = forms.URLField(required=True)
+    body_template = forms.CharField(
+        required=False,
+        strip=False,
+        widget=forms.Textarea,
+        help_text='Optional. A string.Template body; placeholders expand to JSON-encoded values, '
+                  'e.g. {"text": $summary, "url": $issue_url}. Leave blank for the default payload.',
+    )
+
+    def __init__(self, *args, **kwargs):
+        config = kwargs.pop("config", None)
+
+        super().__init__(*args, **kwargs)
+        if config:
+            self.fields["webhook_url"].initial = config.get("webhook_url", "")
+            self.fields["body_template"].initial = config.get("body_template", "")
+
+    def get_config(self):
+        return {
+            "webhook_url": self.cleaned_data.get("webhook_url"),
+            "body_template": self.cleaned_data.get("body_template"),
+        }
+
+    def clean_webhook_url(self):
+        webhook_url = self.cleaned_data["webhook_url"]
+        try:
+            validate_webhook_url(webhook_url)
+        except ValueError as e:
+            raise forms.ValidationError(str(e)) from e
+        return webhook_url
+
+    def clean_body_template(self):
+        body_template = self.cleaned_data.get("body_template")
+        if body_template:
+            context = {key: json.dumps(value) for key, value in _sample_raw_context().items()}
+            rendered = string.Template(body_template).safe_substitute(context)
+            try:
+                json.loads(rendered)
+            except (json.JSONDecodeError, ValueError) as e:
+                raise forms.ValidationError(
+                    'Body template must render to valid JSON. Put a bare $placeholder where a JSON value '
+                    'belongs, e.g. {"text": $summary}. (rendered output was not valid JSON: %(err)s)',
+                    params={"err": str(e)},
+                ) from e
+        return body_template
+
+
+def _store_failure_info(service_config_id, exception, response=None):
+    """Store failure information in the MessagingServiceConfig with immediate_atomic"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+
+            config.last_failure_timestamp = timezone.now()
+            config.last_failure_error_type = type(exception).__name__
+            config.last_failure_error_message = str(exception)
+
+            # Handle requests-specific errors
+            if response is not None:
+                config.last_failure_status_code = response.status_code
+                config.last_failure_response_text = response.text[:2000]  # Limit response text size
+
+                # Check if response is JSON
+                try:
+                    json.loads(response.text)
+                    config.last_failure_is_json = True
+                except (json.JSONDecodeError, ValueError):
+                    config.last_failure_is_json = False
+            else:
+                # Non-HTTP errors
+                config.last_failure_status_code = None
+                config.last_failure_response_text = None
+                config.last_failure_is_json = None
+
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+def _store_success_info(service_config_id):
+    """Clear failure information on successful operation"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+            config.clear_failure_status()
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+@shared_task
+def webhook_backend_send_test_message(webhook_url, project_name, display_name, service_config_id, body_template=None):
+    summary = f"Test message by Bugsink to test the webhook setup (project: {project_name}, backend: {display_name})."
+
+    raw_context = _build_raw_context(
+        summary=summary,
+        issue_title="Test issue",
+        issue_url=get_settings().BASE_URL,
+        project=project_name,
+        alert_reason="TEST",
+        issue_id="test",
+        issue_friendly_id="PROJ-42",
+        unmute_reason=None,
+    )
+    default_data = {
+        "text": summary,
+        "issue": None,
+    }
+    body = _render_body(body_template, raw_context, default_data)
+
+    try:
+        result = WebhookBackend.safe_post(
+            webhook_url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, 'response', None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+@shared_task
+def webhook_backend_send_alert(
+        webhook_url, issue_id, state_description, alert_article, alert_reason, service_config_id,
+        unmute_reason=None, body_template=None):
+
+    issue = Issue.objects.get(id=issue_id)
+
+    issue_url = get_settings().BASE_URL + issue.get_absolute_url()
+    title = truncatechars(issue.title(), 200)
+    summary = f"{alert_reason} issue: {title} - {issue_url}"
+
+    raw_context = _build_raw_context(
+        summary=summary,
+        issue_title=title,
+        issue_url=issue_url,
+        project=issue.project.name,
+        alert_reason=alert_reason,
+        issue_id=str(issue.id),
+        issue_friendly_id=issue.friendly_id(),
+        unmute_reason=unmute_reason,
+    )
+    default_data = {
+        "text": summary,
+        "issue": {
+            "title": title,
+            "url": issue_url,
+            "project": issue.project.name,
+            "state": alert_reason,
+        },
+        "unmute_reason": unmute_reason,
+    }
+    body = _render_body(body_template, raw_context, default_data)
+
+    try:
+        result = WebhookBackend.safe_post(
+            webhook_url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, 'response', None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+class WebhookBackend(BaseWebhookBackend):
+    def __init__(self, service_config):
+        self.service_config = service_config
+
+    @classmethod
+    def get_form_class(cls):
+        return GenericWebhookConfigForm
+
+    def send_test_message(self):
+        config = json.loads(self.service_config.config)
+        webhook_backend_send_test_message.delay(
+            config["webhook_url"],
+            self.service_config.project.name,
+            self.service_config.display_name,
+            self.service_config.id,
+            body_template=config.get("body_template"),
+        )
+
+    def send_alert(self, issue_id, state_description, alert_article, alert_reason, **kwargs):
+        config = json.loads(self.service_config.config)
+        webhook_backend_send_alert.delay(
+            config["webhook_url"],
+            issue_id,
+            state_description,
+            alert_article,
+            alert_reason,
+            self.service_config.id,
+            body_template=config.get("body_template"),
+            **kwargs,
+        )

--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -17,9 +17,11 @@ from teams.models import Team, TeamMembership
 from .models import MessagingServiceConfig
 from .service_backends.slack import slack_backend_send_test_message, slack_backend_send_alert
 from .service_backends.discord import discord_backend_send_test_message, discord_backend_send_alert
+from .service_backends.webhook import webhook_backend_send_test_message, webhook_backend_send_alert
 from .service_backends.discord import DiscordConfigForm
 from .service_backends.mattermost import MattermostConfigForm
 from .service_backends.slack import SlackConfigForm
+from .service_backends.webhook import GenericWebhookConfigForm
 from .service_backends.webhook_security import validate_webhook_url
 from .tasks import send_new_issue_alert, send_regression_alert, send_unmute_alert, _get_users_for_email_alert
 from .views import DEBUG_CONTEXTS
@@ -619,3 +621,373 @@ class TestWebhookConfigForms(DjangoTestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("non-global IP address", form.errors["webhook_url"][0])
+
+    def test_webhook_form_rejects_blocked_target(self):
+        form = GenericWebhookConfigForm(data={"webhook_url": "http://10.0.0.42/hooks/test"})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("non-global IP address", form.errors["webhook_url"][0])
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_accepts_public_target(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={"webhook_url": "https://hooks.example.com/webhook"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.get_config(),
+            {"webhook_url": "https://hooks.example.com/webhook", "body_template": ""},
+        )
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_config_includes_body_template(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": $summary}',
+        })
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.get_config(), {
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": $summary}',
+        })
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_prefills_body_template_from_config(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(config={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": $summary}',
+        })
+
+        self.assertEqual(form.fields["body_template"].initial, '{"text": $summary}')
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_accepts_valid_template(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": $summary, "id": $issue_friendly_id}',
+        })
+
+        self.assertTrue(form.is_valid())
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_rejects_typoed_placeholder(self, mock_resolve):
+        # $summry is a typo: left literal by safe_substitute, so a bareword json.loads rejects.
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": $summry}',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("valid JSON", form.errors["body_template"][0])
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_rejects_quoted_placeholder(self, mock_resolve):
+        # placeholders already expand to JSON-encoded values; wrapping in quotes yields ""..."".
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": '{"text": "$summary"}',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("valid JSON", form.errors["body_template"][0])
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_webhook_form_rejects_whitespace_only_template(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = GenericWebhookConfigForm(data={
+            "webhook_url": "https://hooks.example.com/webhook",
+            "body_template": "   ",
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("valid JSON", form.errors["body_template"][0])
+
+
+class TestGenericWebhookBackend(DjangoTestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test project")
+        self.config = MessagingServiceConfig.objects.create(
+            project=self.project,
+            display_name="Test Webhook",
+            kind="webhook",
+            config=json.dumps({"webhook_url": "https://hooks.example.com/webhook"}),
+        )
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_test_message_success_clears_failure_status(self, mock_post):
+        self.config.last_failure_timestamp = timezone.now()
+        self.config.last_failure_status_code = 500
+        self.config.save()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_test_message(
+            "https://hooks.example.com/webhook",
+            "Test project",
+            "Test Webhook",
+            self.config.id,
+        )
+
+        self.config.refresh_from_db()
+        self.assertIsNone(self.config.last_failure_timestamp)
+
+        # payload shape: human-readable text + issue=None for test messages
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertIn("Test message", sent["text"])
+        self.assertIsNone(sent["issue"])
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_message_payload_shape(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+        )
+
+        self.config.refresh_from_db()
+        self.assertIsNone(self.config.last_failure_timestamp)
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertIn("NEW issue:", sent["text"])
+        self.assertEqual(sent["issue"]["project"], "Test project")
+        self.assertEqual(sent["issue"]["state"], "NEW")
+        self.assertTrue(sent["issue"]["url"].endswith(issue.get_absolute_url()))
+        self.assertIsNone(sent["unmute_reason"])
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_message_includes_unmute_reason(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "Unmuted issue",
+            "an",
+            "UNMUTED",
+            self.config.id,
+            unmute_reason="volume based unmute",
+        )
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(sent["unmute_reason"], "volume based unmute")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_test_message_http_error_stores_failure(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = '{"error": "not_found"}'
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_test_message(
+            "https://hooks.example.com/webhook",
+            "Test project",
+            "Test Webhook",
+            self.config.id,
+        )
+
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertEqual(self.config.last_failure_status_code, 404)
+        self.assertTrue(self.config.last_failure_is_json)
+        self.assertEqual(self.config.last_failure_error_type, "HTTPError")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_test_message_connection_error_stores_failure(self, mock_post):
+        mock_post.side_effect = requests.ConnectionError("Connection failed")
+
+        webhook_backend_send_test_message(
+            "https://hooks.example.com/webhook",
+            "Test project",
+            "Test Webhook",
+            self.config.id,
+        )
+
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertIsNone(self.config.last_failure_status_code)
+        self.assertEqual(self.config.last_failure_error_type, "ConnectionError")
+
+    @patch('alerts.service_backends.base.requests.post')
+    def test_test_message_blocked_target_stores_failure_without_network_call(self, mock_post):
+        webhook_backend_send_test_message(
+            "http://10.0.0.42/hooks/test",
+            "Test project",
+            "Test Webhook",
+            self.config.id,
+        )
+
+        mock_post.assert_not_called()
+        self.config.refresh_from_db()
+        self.assertEqual(self.config.last_failure_error_type, "ValueError")
+        self.assertIn("non-global IP address", self.config.last_failure_error_message)
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_custom_template_renders_valid_json(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+            body_template='{"text": $summary, "reason": $alert_reason, "url": $issue_url}',
+        )
+
+        # the rendered body is valid JSON, and only carries the template's keys (not the default shape)
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(set(sent.keys()), {"text", "reason", "url"})
+        self.assertIn("NEW issue:", sent["text"])
+        self.assertEqual(sent["reason"], "NEW")
+        self.assertTrue(sent["url"].endswith(issue.get_absolute_url()))
+
+    @patch('issues.models.Issue.title', return_value='Broke on "quotes" and\nnewlines')
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_custom_template_quoted_title_stays_valid_json(self, mock_post, mock_title):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+            body_template='{"title": $issue_title}',
+        )
+
+        # JSON-encoded substitution keeps the body valid despite quotes/newlines in the title
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(sent["title"], 'Broke on "quotes" and\nnewlines')
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_custom_template_missing_unmute_reason_renders_null(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+            body_template='{"unmute_reason": $unmute_reason}',
+        )
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertIsNone(sent["unmute_reason"])
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_test_message_custom_template_renders_valid_json(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_test_message(
+            "https://hooks.example.com/webhook",
+            "Test project",
+            "Test Webhook",
+            self.config.id,
+            body_template='{"text": $summary, "reason": $alert_reason}',
+        )
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertIn("Test message", sent["text"])
+        self.assertEqual(sent["reason"], "TEST")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_empty_body_template_posts_default_payload(self, mock_post):
+        # production persists "" for a blank field (not None); "" must fall back to the default payload.
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+            body_template="",
+        )
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertIn("NEW issue:", sent["text"])
+        self.assertEqual(sent["issue"]["project"], "Test project")
+        self.assertEqual(sent["issue"]["state"], "NEW")
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_alert_custom_template_friendly_id(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        webhook_backend_send_alert(
+            "https://hooks.example.com/webhook",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+            unmute_reason=None,
+            body_template='{"id": $issue_friendly_id}',
+        )
+
+        sent = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(sent["id"], issue.friendly_id())


### PR DESCRIPTION
## Configurable generic (neutral) outgoing-webhook alert backend

Relates to #429 ("Add 'custom' webhook destination").

### Motivation

Bugsink 2.3.x ships alert backends for Slack, Mattermost and Discord — all chat-product specific. There is no *neutral*
target, so self-hosters who want alerts in any other system have nothing product-agnostic to point at. A concrete case:
routing alerts into **Matrix via [matrix-hookshot](https://matrix-org.github.io/matrix-hookshot/latest/setup/webhooks.html)
generic webhooks**, but the same applies to n8n, Zapier-style receivers, or a small home-grown endpoint.

This PR adds a `webhook` (generic) backend that POSTs JSON to any URL. It works out of the box with a sensible default
payload, **and** lets the user shape the request body to match whatever schema their receiver expects — which is really
the point of a *generic* webhook. (There is also a fixed-payload proposal in #433; this PR is the shapeable variant. The
two aren't mutually exclusive and the maintainer may prefer either or a blend.)

### Default payload

If no body template is configured, a neutral, self-describing default is sent (`Content-Type: application/json`). The
top-level `text` is a human-readable one-liner so consumers that only read `text` (many chat bridges, incl.
matrix-hookshot generic webhooks) still show something useful; the structured `issue` object is there for consumers that
route/format on individual fields.

```json
{
  "text": "<alert_reason> issue: <title> - <issue_url>",
  "issue": {
    "title": "<issue title>",
    "url": "<BASE_URL + issue.get_absolute_url()>",
    "project": "<project name>",
    "state": "<alert_reason, e.g. NEW / REGRESSED / UNMUTED>"
  },
  "unmute_reason": "<string or null>"
}
```

Test message: same shape with `"issue": null`.

### Optional body template (the shapeable part)

Set a `body_template` to control the exact request body. Rendering uses the Python **standard-library
`string.Template`** (`safe_substitute`) — deliberately **not** Django templates and **not** `eval`/`str.format` on
untrusted input. This is a minimal-attack-surface choice: no logic, no loops, no code execution — just `$name`
substitution.

Every placeholder expands to a **JSON-encoded** value, so you place a bare `$var` exactly where a JSON value belongs and
the output is valid JSON even when a title contains `"` or newlines:

```
{"text": $summary, "url": $issue_url, "reason": $alert_reason}
```

Available placeholders (all JSON-encoded; strings arrive with their surrounding quotes, `None` → `null`):

| Placeholder | Value |
|---|---|
| `$summary` | human-readable one-liner |
| `$issue_title` | the issue title |
| `$issue_url` | absolute Bugsink URL of the issue |
| `$project` | project name |
| `$alert_reason` | e.g. `NEW` / `REGRESSED` / `UNMUTED` |
| `$issue_id` | the issue id (string) |
| `$issue_friendly_id` | human-facing id, e.g. `PROJ-42` |
| `$unmute_reason` | unmute reason, or `null` |

Unknown `$placeholders` are left literal (`safe_substitute`). Content-type is fixed to `application/json`; a custom
content-type / form-encoding is possible future work.

**Templates are validated at save time.** The config form renders the template against a representative sample context
and `json.loads()` the result; a template that doesn't produce valid JSON (a typo'd/quoted placeholder, whitespace, or
structural breakage) is rejected in the form rather than silently POSTing broken JSON to a lenient receiver (e.g.
matrix-hookshot, which answers `200` and hides it). The sample context and the runtime context share one key-set
definition so they can't drift.

### Implementation

Follows the existing Slack/Mattermost/Discord backend pattern exactly:

- `alerts/service_backends/webhook.py`
  - `GenericWebhookConfigForm` — SSRF-validated `webhook_url` + optional `body_template` (Textarea); `get_config()`
    carries both; `__init__(config=...)` pre-fills both.
  - `@shared_task` `webhook_backend_send_test_message` / `webhook_backend_send_alert` — same SSRF `safe_post`, no
    redirects, timeout, and the same `_store_failure_info` / `_store_success_info` tracking as Slack (helpers kept
    per-module, matching current convention). A small `_render_body()` helper does template-or-default.
  - `WebhookBackend(BaseWebhookBackend)` — reads `body_template` from config and passes it into the `.delay(...)` calls.
- `alerts/models.py` — `("webhook", "Webhook (generic)")` choice + dispatch. `kind` already uses a callable `choices`,
  so **no migration** is needed.
- `CHANGELOG.md` — unreleased entry.

The user-facing alerts docs live on bugsink.com (not in this repo); happy to prep a matching docs change there. The
placeholder list and JSON-encoding contract are documented in the module docstring and above.

### Tests

Mirrors the existing Slack/Discord tests, plus template coverage: default payload unchanged when no template is set
(both `None` and an empty string), custom template renders valid JSON, a title containing `"` and newlines still yields
valid JSON via `$issue_title`, `$issue_friendly_id` renders, missing `unmute_reason` renders JSON `null`, save-time
validation rejects typo'd/quoted/whitespace-only templates, and `get_config()` includes `body_template`.

```
$ python manage.py test alerts --exclude-tag=samples
Ran 57 tests in 0.228s
OK
```

(37 on `main`, 57 with this PR.) `ruff check .` passes clean.

### Feedback wanted

- **Placeholder set / naming** — is `$summary`, `$issue_title`, `$issue_url`, `$project`, `$alert_reason`, `$issue_id`,
  `$issue_friendly_id`, `$unmute_reason` the right surface, or would you add/rename any?
- **Default payload shape** — happy to adjust field names / structure.
- **Follow-ups** — a configurable content-type (form-encoding / custom header) and exposing release/environment once
  those are threaded through to the send function.

No rush — draft for your review of the approach and the template contract.
