### PR TITLE
Make EMAIL_BACKEND Docker-configurable

### DIFF
--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -91,7 +91,9 @@ else:
     database_path = os.path.dirname(DATABASES['default']['NAME'])
 
 
-if os.getenv("EMAIL_HOST"):
+if os.getenv("EMAIL_BACKEND"):
+    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+elif os.getenv("EMAIL_HOST"):
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"  # default, here for explicitness
     EMAIL_HOST = os.getenv("EMAIL_HOST")
     EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")


### PR DESCRIPTION
Docker previously derived `EMAIL_BACKEND` from `EMAIL_HOST` only. That meant Django's dummy.EmailBackend could be configured in a Python config file, but not through Docker environment variables.

Docker deployments can now set `EMAIL_BACKEND` directly. In particular, `EMAIL_BACKEND=django.core.mail.backends.dummy.EmailBackend` intentionally disables email and keeps the existing no-email warning behavior quiet.

Fix #247