### PR TITLE
Show 'many issues' when open count is skipped

### DIFF
--- a/projects/templates/projects/project_list.html
+++ b/projects/templates/projects/project_list.html
@@ -74,6 +74,8 @@
                     | {{ project.member_count }} {% translate "members" %}
                     {% if project.open_issue_count != None %}
                     | {{ project.open_issue_count }} {% translate "open issues" %}
+                    {% else %}
+                    | {% translate "many issues" %} {# note: how many 'open' is unknown so we don't say that; when there are "many" issues (a number we denormalize) we don't try to count the open ones #}
                     {% endif %}
                     {% if project.member %}
                     | <a href="{% url 'project_member_settings' project_pk=project.id user_pk=request.user.id %}" class="font-bold text-cyan-500 dark:text-cyan-300">{% translate "my settings" %}</a>

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -214,6 +214,7 @@ class ProjectListOpenIssueCountTestCase(TransactionTestCase):
             response = self.client.get("/projects/mine/")
 
         issue_filter.assert_not_called()
+        self.assertContains(response, "many issues")
         self.assertNotContains(response, "open issues")
 
 


### PR DESCRIPTION
When there are very many issues (currently > 25,000) on a project, we don't count them on the project-list because this is expensive. UI-wise, this made it so that the projects with the most issues actually looked like there were no issues at all. Display "many issues" instead.