### PR TITLE
Email: hourly quota and sending diagnostics

### DIFF
--- a/bugsink/app_settings.py
+++ b/bugsink/app_settings.py
@@ -71,6 +71,9 @@ DEFAULTS = {
     "MAX_EVENTS_PER_HOUR": 5_000,
     "MAX_EVENTS_PER_MONTH": 1_000_000,
 
+    # Sending more than 1 email per minute sustained is self-spam territory, and should require explicit configuration.
+    # Extra benefit of this default: it avoids hogging Snappea workers accidentally.
+    "MAX_EMAILS_PER_HOUR": 60,
     "MAX_EMAILS_PER_MONTH": None,  # None means "no limit"; for non-None values, the quota is per calendar month
 
     "MAX_RETENTION_PER_PROJECT_EVENT_COUNT": None,  # None means "no limit"

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -167,6 +167,9 @@ BUGSINK = {
     "MAX_EVENTS_PER_HOUR": int(os.getenv("MAX_EVENTS_PER_HOUR", 5_000)),
     "MAX_EVENTS_PER_MONTH": int(os.getenv("MAX_EVENTS_PER_MONTH", 1_000_000)),
 
+    "MAX_EMAILS_PER_HOUR": int_or_none(os.getenv("MAX_EMAILS_PER_HOUR", 60)),
+    "MAX_EMAILS_PER_MONTH": int_or_none(os.getenv("MAX_EMAILS_PER_MONTH", None)),
+
     "MAX_RETENTION_PER_PROJECT_EVENT_COUNT": int_or_none(os.getenv("MAX_RETENTION_PER_PROJECT_EVENT_COUNT", None)),
     "MAX_RETENTION_EVENT_COUNT": int_or_none(os.getenv("MAX_RETENTION_EVENT_COUNT", None)),
     "MAX_EVENT_AGE_DAYS": int_or_none(os.getenv("MAX_EVENT_AGE_DAYS", None)),

--- a/bugsink/conf_templates/local.py.template
+++ b/bugsink/conf_templates/local.py.template
@@ -83,6 +83,9 @@ BUGSINK = {
     # "MAX_CSP_REPORT_SIZE": 64 * _KIBIBYTE,
     # "MAX_EVENT_TAGS": 100,
 
+    # "MAX_EMAILS_PER_HOUR": 60,
+    # "MAX_EMAILS_PER_MONTH": None,
+
     # Webhook outbound security:
     # "ALERTS_WEBHOOK_OUTBOUND_MODE": "open",  # or "allowlist_only"
     # "ALERTS_WEBHOOK_ALLOW_LIST": ["hooks.example.com", "203.0.113.0/24"],

--- a/bugsink/conf_templates/singleserver.py.template
+++ b/bugsink/conf_templates/singleserver.py.template
@@ -117,6 +117,9 @@ BUGSINK = {
     # For large MAX_FILE_SIZE values, you may want OBJECT_STORAGES["file"] configured too.
     # "MAX_FILE_SIZE": 2 * _GIBIBYTE,
 
+    # "MAX_EMAILS_PER_HOUR": 60,
+    # "MAX_EMAILS_PER_MONTH": None,
+
     "INGEST_STORE_BASE_DIR": "{{ base_dir }}/ingestion",
 
     # Optionally, you can set the following to True to further minimize information exposure in the UI. (The default is

--- a/bugsink/context_processors.py
+++ b/bugsink/context_processors.py
@@ -55,6 +55,27 @@ def get_email_failure_warnings(installation, now):
         None)]
 
 
+def get_email_quota_warnings(installation, now):
+    warnings = []
+    email_quota_usage = json.loads(installation.email_quota_usage)
+
+    if get_settings().MAX_EMAILS_PER_HOUR is not None:
+        this_hour_usage = email_quota_usage.get("per_hour", {}).get(now.strftime("%Y-%m-%dT%H"), 0)
+        if this_hour_usage >= get_settings().MAX_EMAILS_PER_HOUR:
+            warnings.append(SystemWarning(
+                f"Bugsink has sent {this_hour_usage} emails this hour, which is the maximum. "
+                "No more emails will be sent until the next hour.", None))
+
+    if get_settings().MAX_EMAILS_PER_MONTH is not None:
+        this_month_usage = email_quota_usage.get("per_month", {}).get(now.strftime("%Y-%m"), 0)
+        if this_month_usage >= get_settings().MAX_EMAILS_PER_MONTH:
+            warnings.append(SystemWarning(
+                f"Bugsink has sent {this_month_usage} emails this month, which is the maximum. "
+                "No more emails will be sent until the 1st of next month.", None))
+
+    return warnings
+
+
 def get_snappea_warnings():
     # We warn in either of 2 cases, as documented per-case.
 
@@ -147,16 +168,9 @@ def useful_settings_processor(request):
 
             system_warnings.append(SystemWarning(EMAIL_BACKEND_WARNING, ignore_url))
 
-        if get_settings().MAX_EMAILS_PER_MONTH is not None:
-            email_quota_usage = json.loads(installation.email_quota_usage)
-            this_month_usage = email_quota_usage.get("per_month", {}).get(timezone.now().strftime("%Y-%m"), 0)
-            if this_month_usage >= get_settings().MAX_EMAILS_PER_MONTH:
-                system_warnings.append(SystemWarning(
-                    f"Bugsink has sent {this_month_usage} emails this month, which is the maximum. "
-                    "No more emails will be sent until the 1st of next month.", None))
-
         # copy pasted from project/models.py
         now = datetime.now(dt_timezone.utc)
+        system_warnings.extend(get_email_quota_warnings(installation, now))
         system_warnings.extend(get_email_failure_warnings(installation, now))
 
         from ingest.views import BaseIngestAPIView

--- a/bugsink/context_processors.py
+++ b/bugsink/context_processors.py
@@ -33,6 +33,28 @@ EMAIL_BACKEND_WARNING = mark_safe(
     dark:text-slate-100">set up email</a>.""")  # nosec
 
 
+def get_email_failure_warnings(installation, now):
+    diagnostics = json.loads(installation.email_sending_diagnostics)
+    cutoff = now - timedelta(minutes=5)
+    recent_attempts = []
+
+    for attempt in diagnostics.get("attempts", []):
+        attempted_at = datetime.fromisoformat(attempt["at"])
+        if attempted_at >= cutoff:
+            recent_attempts.append(attempt)
+
+    if len(recent_attempts) < 5:
+        return []
+
+    failures = len([attempt for attempt in recent_attempts if not attempt.get("ok")])
+    if failures * 2 <= len(recent_attempts):
+        return []
+
+    return [SystemWarning(
+        f"Email sending appears to be failing: {failures} of {len(recent_attempts)} recent email attempts failed.",
+        None)]
+
+
 def get_snappea_warnings():
     # We warn in either of 2 cases, as documented per-case.
 
@@ -135,6 +157,8 @@ def useful_settings_processor(request):
 
         # copy pasted from project/models.py
         now = datetime.now(dt_timezone.utc)
+        system_warnings.extend(get_email_failure_warnings(installation, now))
+
         from ingest.views import BaseIngestAPIView
         if BaseIngestAPIView.is_quota_still_exceeded(installation, now):
             period_name, nr_of_periods, gte_threshold = json.loads(installation.quota_exceeded_reason)

--- a/bugsink/tests.py
+++ b/bugsink/tests.py
@@ -62,7 +62,9 @@ class SendRenderedEmailTestCase(SimpleTestCase):
 
     @override_settings(DEFAULT_FROM_EMAIL="Bugsink <alerts@bugsink.com>", ALLOWED_HOSTS=["tenant.bugsink.com"])
     @patch("phonehome.models.Installation.check_and_inc_email_quota", return_value=True)
-    def test_send_rendered_email_allows_bugsink_sender_domain_when_hosted_on_bugsink_domain(self, _quota_ok):
+    @patch("phonehome.models.Installation.record_email_attempt")
+    def test_send_rendered_email_allows_bugsink_sender_domain_when_hosted_on_bugsink_domain(
+            self, record_attempt, _quota_ok):
         send_rendered_email(
             "Subject",
             "mails/welcome_email",
@@ -71,6 +73,7 @@ class SendRenderedEmailTestCase(SimpleTestCase):
         )
 
         self.assertEqual(1, len(mail.outbox))
+        record_attempt.assert_called_once()
 
 
 class StreamsTestCase(RegularTestCase):

--- a/bugsink/utils.py
+++ b/bugsink/utils.py
@@ -1,5 +1,6 @@
 import random
 import logging
+import time
 from collections import defaultdict
 
 from django.utils import timezone
@@ -94,7 +95,14 @@ def send_rendered_email(subject, base_template_name, recipient_list, context=Non
 
     msg.attach_alternative(html_content, "text/html")
 
-    msg.send(fail_silently=False)  # (fail_silently=False is the default)
+    t0 = time.monotonic()
+    try:
+        msg.send(fail_silently=False)  # (fail_silently=False is the default)
+    except Exception as e:
+        Installation.record_email_attempt(False, time.monotonic() - t0, e.__class__.__name__)
+        raise
+    else:
+        Installation.record_email_attempt(True, time.monotonic() - t0)
 
 
 def get_model_topography():

--- a/phonehome/migrations/0007_installation_email_sending_diagnostics.py
+++ b/phonehome/migrations/0007_installation_email_sending_diagnostics.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("phonehome", "0006_recalculate_installation_next_quota_check"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="installation",
+            name="email_sending_diagnostics",
+            field=models.TextField(default='{"attempts": []}'),
+        ),
+    ]

--- a/phonehome/models.py
+++ b/phonehome/models.py
@@ -2,9 +2,12 @@ import json
 import uuid
 
 from django.db import models
+from django.utils import timezone
 from bugsink.transaction import immediate_atomic
 
 from bugsink.app_settings import get_settings
+
+EMAIL_ATTEMPTS_MAX = 10
 
 
 class Installation(models.Model):
@@ -18,12 +21,16 @@ class Installation(models.Model):
 
     # ingestion/digestion quota
     email_quota_usage = models.TextField(null=False, default='{"per_month": {}}')
+    email_sending_diagnostics = models.TextField(null=False, default='{"attempts": []}')
     quota_exceeded_until = models.DateTimeField(null=True, blank=True)
     quota_exceeded_reason = models.CharField(max_length=255, null=False, default="null")
     next_quota_check = models.PositiveIntegerField(null=False, default=0)
 
     @classmethod
-    @immediate_atomic(only_if_needed=True)  # minimalize write-lock-hogging (while being callable within atomic blocks)
+    # minimalize write-lock-hogging (while being callable within atomic blocks; i.e. we accept that we lose the "is
+    # outer" guarantee (that would be very nice for email sending) to be able to run from inside TASK_ALWAYS_EAGER
+    # tasks.
+    @immediate_atomic(only_if_needed=True)
     def check_and_inc_email_quota(cls, date):
         obj = cls.objects.first()
 
@@ -42,6 +49,30 @@ class Installation(models.Model):
         obj.email_quota_usage = json.dumps(email_quota_usage)
         obj.save()
         return True
+
+    @classmethod
+    # minimalize write-lock-hogging (while being callable within atomic blocks; i.e. we accept that we lose the "is
+    # outer" guarantee (that would be very nice for email sending) to be able to run from inside TASK_ALWAYS_EAGER
+    # tasks.
+    @immediate_atomic(only_if_needed=True)
+    def record_email_attempt(cls, ok, duration, error=None, attempted_at=None):
+        obj = cls.objects.first()
+
+        diagnostics = json.loads(obj.email_sending_diagnostics)
+        attempt = {
+            "at": (attempted_at or timezone.now()).isoformat(),
+            "ok": ok,
+            "duration": round(duration, 3),
+        }
+        if error is not None:
+            attempt["error"] = str(error)[:100]
+
+        attempts = diagnostics.get("attempts", [])
+        attempts.append(attempt)
+        diagnostics["attempts"] = attempts[-EMAIL_ATTEMPTS_MAX:]
+
+        obj.email_sending_diagnostics = json.dumps(diagnostics)
+        obj.save(update_fields=["email_sending_diagnostics"])
 
 
 class OutboundMessage(models.Model):

--- a/phonehome/models.py
+++ b/phonehome/models.py
@@ -36,15 +36,24 @@ class Installation(models.Model):
 
         email_quota_usage = json.loads(obj.email_quota_usage)
 
-        key = date.strftime('%Y-%m')
-        if key not in email_quota_usage["per_month"]:
-            email_quota_usage['per_month'] = {key: 0}  # full overwrite: no need to keep old info around.
+        hour_key = date.strftime('%Y-%m-%dT%H')
+        if hour_key not in email_quota_usage.get("per_hour", {}):
+            email_quota_usage['per_hour'] = {hour_key: 0}  # full overwrite: no need to keep old info around.
 
-        if (get_settings().MAX_EMAILS_PER_MONTH is not None
-                and email_quota_usage['per_month'][key] >= get_settings().MAX_EMAILS_PER_MONTH):
+        month_key = date.strftime('%Y-%m')
+        if month_key not in email_quota_usage["per_month"]:
+            email_quota_usage['per_month'] = {month_key: 0}  # full overwrite: no need to keep old info around.
+
+        if (get_settings().MAX_EMAILS_PER_HOUR is not None
+                and email_quota_usage['per_hour'][hour_key] >= get_settings().MAX_EMAILS_PER_HOUR):
             return False
 
-        email_quota_usage['per_month'][key] += 1
+        if (get_settings().MAX_EMAILS_PER_MONTH is not None
+                and email_quota_usage['per_month'][month_key] >= get_settings().MAX_EMAILS_PER_MONTH):
+            return False
+
+        email_quota_usage['per_hour'][hour_key] += 1
+        email_quota_usage['per_month'][month_key] += 1
 
         obj.email_quota_usage = json.dumps(email_quota_usage)
         obj.save()

--- a/phonehome/tests.py
+++ b/phonehome/tests.py
@@ -1,4 +1,12 @@
+import json
+from datetime import timedelta
+
 from django.test import TestCase
+from django.utils import timezone
+from bugsink.context_processors import get_email_failure_warnings
+from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
+
+from .models import Installation
 from .tasks import _make_message_body
 
 
@@ -7,3 +15,52 @@ class PhoneHomeTests(TestCase):
     def test_make_message_body(self):
         # simple "does not crash" test (at least tests the various database getter code paths don't crash)
         _make_message_body()
+
+
+class EmailSendingDiagnosticsTestCase(TransactionTestCase):
+
+    def test_record_email_attempt_caps_at_ten(self):
+        base = timezone.now()
+
+        for i in range(12):
+            Installation.record_email_attempt(
+                i % 2 == 0,
+                i / 10,
+                "SMTPConnectError" if i % 2 else None,
+                base + timedelta(seconds=i),
+            )
+
+        diagnostics = json.loads(Installation.objects.get().email_sending_diagnostics)
+
+        self.assertEqual(10, len(diagnostics["attempts"]))
+        self.assertEqual((base + timedelta(seconds=2)).isoformat(), diagnostics["attempts"][0]["at"])
+        self.assertEqual((base + timedelta(seconds=11)).isoformat(), diagnostics["attempts"][-1]["at"])
+        self.assertEqual("SMTPConnectError", diagnostics["attempts"][-1]["error"])
+
+    def test_email_failure_warning_uses_recent_failure_rate(self):
+        installation = Installation.objects.get()
+        now = timezone.now()
+        attempts = [
+            {"at": (now - timedelta(minutes=4, seconds=i)).isoformat(), "ok": i < 2, "duration": 0.1}
+            for i in range(5)
+        ]
+        installation.email_sending_diagnostics = json.dumps({"attempts": attempts})
+
+        warnings = get_email_failure_warnings(installation, now)
+
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "Email sending appears to be failing: 3 of 5 recent email attempts failed.",
+            warnings[0].message,
+        )
+
+    def test_email_failure_warning_ignores_old_attempts(self):
+        installation = Installation.objects.get()
+        now = timezone.now()
+        attempts = [
+            {"at": (now - timedelta(minutes=6, seconds=i)).isoformat(), "ok": False, "duration": 0.1}
+            for i in range(10)
+        ]
+        installation.email_sending_diagnostics = json.dumps({"attempts": attempts})
+
+        self.assertEqual([], get_email_failure_warnings(installation, now))

--- a/phonehome/tests.py
+++ b/phonehome/tests.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 
 from django.test import TestCase
 from django.utils import timezone
-from bugsink.context_processors import get_email_failure_warnings
+from bugsink.app_settings import override_settings as override_bugsink_settings
+from bugsink.context_processors import get_email_failure_warnings, get_email_quota_warnings
 from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
 
 from .models import Installation
@@ -64,3 +65,36 @@ class EmailSendingDiagnosticsTestCase(TransactionTestCase):
         installation.email_sending_diagnostics = json.dumps({"attempts": attempts})
 
         self.assertEqual([], get_email_failure_warnings(installation, now))
+
+
+class EmailQuotaTestCase(TransactionTestCase):
+
+    def test_hourly_email_quota(self):
+        now = timezone.now()
+
+        with override_bugsink_settings(MAX_EMAILS_PER_HOUR=2, MAX_EMAILS_PER_MONTH=None):
+            self.assertTrue(Installation.check_and_inc_email_quota(now))
+            self.assertTrue(Installation.check_and_inc_email_quota(now))
+            self.assertFalse(Installation.check_and_inc_email_quota(now))
+
+        usage = json.loads(Installation.objects.get().email_quota_usage)
+        self.assertEqual(2, usage["per_hour"][now.strftime("%Y-%m-%dT%H")])
+        self.assertEqual(2, usage["per_month"][now.strftime("%Y-%m")])
+
+    def test_hourly_email_quota_warning(self):
+        now = timezone.now()
+        installation = Installation.objects.get()
+        installation.email_quota_usage = json.dumps({
+            "per_hour": {now.strftime("%Y-%m-%dT%H"): 2},
+            "per_month": {},
+        })
+
+        with override_bugsink_settings(MAX_EMAILS_PER_HOUR=2, MAX_EMAILS_PER_MONTH=None):
+            warnings = get_email_quota_warnings(installation, now)
+
+        self.assertEqual(1, len(warnings))
+        self.assertEqual(
+            "Bugsink has sent 2 emails this hour, which is the maximum. "
+            "No more emails will be sent until the next hour.",
+            warnings[0].message,
+        )


### PR DESCRIPTION
### Warn when recent email sending fails

This MR records the last 10 actual email send attempts and shows a system warning when recent sending is failing.

The warning is shown when at least 5 email attempts happened in the last 5 minutes and more than half failed. This gives
admins a direct email-level signal instead of making them infer the problem from a generic Snappea backlog warning.

### Limit sustained email sending per hour

This MR adds a calendar-hour email quota:

```python
MAX_EMAILS_PER_HOUR = 60
```

Sending more than 1 email per minute sustained is self-spam territory, and should require explicit configuration.

### Context: snappea-hogging when email is broken

Bugsink already warns when Snappea is backlogged, but that warning does not identify SMTP/email sending as a possible
cause.

One concrete case where this matters is a broken SMTP setup. SMTP can be slow or failing because email is misconfigured,
the SMTP server is down, the network path is blocked, or the SMTP server is overloaded. Bugsink has `EMAIL_TIMEOUT = 5`,
so this should not hang forever, but 5 seconds is still long enough to matter when email attempts happen repeatedly, e.g. for misconfigured grouping combined with large event volumes.

With the default 4 Snappea workers, enough simultaneous SMTP timeouts can occupy all workers. Event processing then
slows down even though the underlying bottleneck is email sending.

There were already partial diagnostics (warning about snappea at top-of-page and`showstat snappea-stats` command could
be used to find slow task types), but they are indirect.

This PR adds the direct email-level solution (quota) and signal (warnings) instead.
