### PR TITLE
Fix stats UTC handling and improve issue sidebar links

### DIFF
--- a/bsmain/management/commands/munin.py
+++ b/bsmain/management/commands/munin.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 from django.db.models import Sum, Max
 
 from bugsink.transaction import durable_atomic

--- a/bsmain/management/commands/showstat.py
+++ b/bsmain/management/commands/showstat.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -88,7 +88,7 @@ class Command(BaseCommand):
                     print(f"  ingestion window: {ingestion_window:.1f}s, factor: {factor:.1f}")
 
     def snappea_stats(self, filter_task_name, window=None):
-        now_floor = datetime(*(datetime.now(timezone.utc).timetuple()[:5]), tzinfo=timezone.utc)
+        now_floor = datetime(*(datetime.now(dt_timezone.utc).timetuple()[:5]), tzinfo=dt_timezone.utc)
 
         print("""past n minutes  task                                              AVG                 SAT    MAX
                                                   done/s err/s   wall   wait  write   sat   wall   wait  write backlog""")  # noqa

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -229,14 +229,14 @@
             </div>
             <div class="p-4">
                 {% for issuetags in issue.tags_summary %}
-                    <div class="mb-4">
+                    <a href="{{ script_prefix }}/issues/issue/{{ issue.id }}/tags/{% current_qs %}" class="block mb-4">
                         <div class="text-sm font-bold text-slate-500 dark:text-slate-300">{{ issuetags.0.key.key }}:</div>
                         <div>
                         {% for issuetag in issuetags %}
                             <span>{{ issuetag.value.value }} <span class="text-xs">({{ issuetag.pct }}%)</span>{% if not forloop.last %}</span>,{% endif %}
                         {% endfor %}
                         </div>
-                    </div>
+                    </a>
                 {% endfor %}
 
                 <div class="text-sm font-bold italic text-slate-500 dark:text-slate-300"><a href="{{ script_prefix }}/issues/issue/{{ issue.id }}/tags/{% current_qs %}">{% translate "All tags..." %}</a></div>

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -210,8 +210,13 @@
                 <div class="mb-4">
                     <div class="text-sm font-bold text-slate-500 dark:text-slate-300">Seen in releases:</div>
                     <div>
-                    {% for version in issue.get_events_at_2 %}
-                        <span {% if version|issha %}class="font-mono"{% endif %}>{{ version|shortsha }}{% if not forloop.last %}</span>,{% endif %}
+                    {% summarized_releases issue.get_events_at_2 as seen_releases %}
+                    {% for item in seen_releases %}
+                        {% if item.hidden_count %}
+                            ... «{{ item.hidden_count }} more» ...{% if item.comma %},{% endif %}
+                        {% else %}
+                            <span {% if item.version|issha %}class="font-mono"{% endif %}>{{ item.version|shortsha }}</span>{% if item.comma %},{% endif %}
+                        {% endif %}
                     {% endfor %}
                     </div>
                 </div>

--- a/issues/tests.py
+++ b/issues/tests.py
@@ -508,6 +508,21 @@ class ViewTests(TransactionTestCase):
         response = self.client.get(f"/issues/issue/{self.issue.id}/tags/")
         self.assertContains(response, self.issue.title())
 
+    def test_issue_sidebar_summarizes_long_release_lists(self):
+        self.issue.events_at = "\n".join(f"2026.1.{i}.0" for i in range(10)) + "\n"
+        self.issue.save()
+
+        response = self.client.get(f"/issues/issue/{self.issue.id}/event/{self.event.id}/")
+
+        self.assertContains(response, "... «4 more» ...,")
+        self.assertContains(response, "2026.1.0.0")
+        self.assertContains(response, "2026.1.1.0")
+        self.assertContains(response, "2026.1.2.0")
+        self.assertContains(response, "2026.1.7.0")
+        self.assertContains(response, "2026.1.8.0")
+        self.assertContains(response, "2026.1.9.0")
+        self.assertNotContains(response, "2026.1.4.0")
+
     def test_issue_grouping(self):
         response = self.client.get(f"/issues/issue/{self.issue.id}/grouping/")
         self.assertContains(response, self.issue.title())

--- a/theme/templatetags/issues.py
+++ b/theme/templatetags/issues.py
@@ -17,6 +17,25 @@ from bugsink.pygments_extensions import guess_lexer_for_filename, lexer_for_plat
 register = template.Library()
 
 
+@register.simple_tag
+def summarized_releases(versions):
+    versions = list(versions)
+    if len(versions) <= 7:
+        return [
+            {"version": version, "comma": i < len(versions) - 1}
+            for i, version in enumerate(versions)
+        ]
+
+    return (
+        [{"version": version, "comma": True} for version in versions[:3]]
+        + [{"hidden_count": len(versions) - 6, "comma": True}]
+        + [
+            {"version": version, "comma": i < 2}
+            for i, version in enumerate(versions[-3:])
+        ]
+    )
+
+
 def _split(joined, lengths):
     result = []
     start = 0


### PR DESCRIPTION
- Fix Snappea stats commands for newer Django UTC handling
- Make issue sidebar tag summaries link to the issue Tags page
- Summarize long “Seen in releases” lists as oldest entries, hidden count, newest entries