### PR TITLE
Add Microsoft Teams as a messaging backend for alerts

### DIFF
--- a/alerts/models.py
+++ b/alerts/models.py
@@ -6,6 +6,7 @@ from .service_backends.mattermost import MattermostBackend
 from .service_backends.discord import DiscordBackend
 from .service_backends.telegram import TelegramBackend
 from .service_backends.custom import CustomBackend
+from .service_backends.msteams import MsTeamsBackend
 
 
 def get_alert_service_kind_choices():
@@ -14,6 +15,7 @@ def get_alert_service_kind_choices():
     return [
         ("discord", "Discord"),
         ("mattermost", "Mattermost"),
+        ("msteams", "Microsoft Teams"),
         ("slack", "Slack"),
         ("telegram", "Telegram"),
         ("custom", "Custom"),
@@ -25,6 +27,8 @@ def get_alert_service_backend_class(kind):
         return DiscordBackend
     if kind == "mattermost":
         return MattermostBackend
+    if kind == "msteams":
+        return MsTeamsBackend
     if kind == "slack":
         return SlackBackend
     if kind == "telegram":

--- a/alerts/service_backends/msteams.py
+++ b/alerts/service_backends/msteams.py
@@ -1,0 +1,262 @@
+import json
+import requests
+from django.utils import timezone
+
+from django import forms
+from django.template.defaultfilters import truncatechars
+
+from snappea.decorators import shared_task
+from bugsink.app_settings import get_settings
+from bugsink.transaction import immediate_atomic
+
+from issues.models import Issue
+from .base import BaseWebhookBackend
+from .webhook_security import validate_webhook_url
+
+
+class MsTeamsConfigForm(forms.Form):
+    # Workflow ("Post to a channel when a webhook request is received") URLs are much longer than the 200 chars that
+    # URLField defaults to.
+    webhook_url = forms.URLField(required=True, assume_scheme="https", max_length=1000)
+
+    # Microsoft Teams does not support multi-channel webhooks: the channel is picked when the workflow is created.
+
+    def __init__(self, *args, **kwargs):
+        config = kwargs.pop("config", None)
+
+        super().__init__(*args, **kwargs)
+        if config:
+            self.fields["webhook_url"].initial = config.get("webhook_url", "")
+
+    def get_config(self):
+        return {
+            "webhook_url": self.cleaned_data.get("webhook_url"),
+        }
+
+    def clean_webhook_url(self):
+        webhook_url = self.cleaned_data["webhook_url"]
+        try:
+            validate_webhook_url(webhook_url)
+        except ValueError as e:
+            raise forms.ValidationError(str(e)) from e
+        return webhook_url
+
+
+def _safe_markdown(text):
+    # Adaptive Card TextBlocks render a subset of markdown; escape the characters that carry meaning in it.
+    return (text.replace("\\", "\\\\").replace("*", "\\*").replace("_", "\\_")
+                .replace("[", "\\[").replace("]", "\\]").replace("#", "\\#").replace("-", "\\-"))
+
+
+def _as_message(card_body, actions=None):
+    # Teams expects an Adaptive Card wrapped in an attachment; see
+    # https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference
+    content = {
+        "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.4",
+        "body": card_body,
+    }
+
+    if actions:
+        content["actions"] = actions
+
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": content,
+            }
+        ],
+    }
+
+
+def _store_failure_info(service_config_id, exception, response=None):
+    """Store failure information in the MessagingServiceConfig with immediate_atomic"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+
+            config.last_failure_timestamp = timezone.now()
+            config.last_failure_error_type = type(exception).__name__
+            config.last_failure_error_message = str(exception)
+
+            # Handle requests-specific errors
+            if response is not None:
+                config.last_failure_status_code = response.status_code
+                config.last_failure_response_text = response.text[:2000]  # Limit response text size
+
+                # Check if response is JSON
+                try:
+                    json.loads(response.text)
+                    config.last_failure_is_json = True
+                except (json.JSONDecodeError, ValueError):
+                    config.last_failure_is_json = False
+            else:
+                # Non-HTTP errors
+                config.last_failure_status_code = None
+                config.last_failure_response_text = None
+                config.last_failure_is_json = None
+
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+def _store_success_info(service_config_id):
+    """Clear failure information on successful operation"""
+    from alerts.models import MessagingServiceConfig
+
+    with immediate_atomic(only_if_needed=True):
+        try:
+            config = MessagingServiceConfig.objects.get(id=service_config_id)
+            config.clear_failure_status()
+            config.save()
+        except MessagingServiceConfig.DoesNotExist:
+            # Config was deleted while task was running
+            pass
+
+
+@shared_task
+def msteams_backend_send_test_message(webhook_url, project_name, display_name, service_config_id):
+    data = _as_message([
+        {
+            "type": "TextBlock",
+            "text": "TEST issue",
+            "size": "Large",
+            "weight": "Bolder",
+            "wrap": True,
+        },
+        {
+            "type": "TextBlock",
+            "text": "Test message by Bugsink to test the webhook setup.",
+            "wrap": True,
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {"title": "project", "value": _safe_markdown(project_name)},
+                {"title": "message backend", "value": _safe_markdown(display_name)},
+            ],
+        },
+    ])
+
+    try:
+        result = MsTeamsBackend.safe_post(
+            webhook_url,
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, 'response', None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+@shared_task
+def msteams_backend_send_alert(
+        webhook_url, issue_id, state_description, alert_article, alert_reason, service_config_id, unmute_reason=None):
+
+    issue = Issue.objects.get(id=issue_id)
+
+    issue_url = get_settings().BASE_URL + issue.get_absolute_url()
+
+    body = [
+        {
+            "type": "TextBlock",
+            "text": _safe_markdown(truncatechars(issue.title(), 150)),
+            "size": "Large",
+            "weight": "Bolder",
+            "wrap": True,
+        },
+        {
+            "type": "TextBlock",
+            "text": f"{alert_reason} issue",
+            "wrap": True,
+        },
+    ]
+
+    if unmute_reason:
+        body.append({
+            "type": "TextBlock",
+            "text": _safe_markdown(unmute_reason),
+            "wrap": True,
+        })
+
+    # assumption: visavis email, project.name is of less importance, because in slack-like things you may (though not
+    # always) do one-channel per project. more so for site_title (if you have multiple Bugsinks, you'll surely have
+    # multiple teams channels)
+    facts = [{"title": "project", "value": _safe_markdown(issue.project.name)}]
+
+    # left as a (possible) TODO, because the amount of refactoring (passing event to this function) is too big for now
+    # if event.release:
+    #     facts.append({"title": "release", "value": _safe_markdown(event.release)})
+    # if event.environment:
+    #     facts.append({"title": "environment", "value": _safe_markdown(event.environment)})
+
+    body.append({"type": "FactSet", "facts": facts})
+
+    data = _as_message(body, actions=[
+        {
+            "type": "Action.OpenUrl",
+            "title": "view on Bugsink",
+            "url": issue_url,
+        },
+    ])
+
+    try:
+        result = MsTeamsBackend.safe_post(
+            webhook_url,
+            data=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+        )
+
+        result.raise_for_status()
+
+        _store_success_info(service_config_id)
+    except requests.RequestException as e:
+        response = getattr(e, 'response', None)
+        _store_failure_info(service_config_id, e, response)
+
+    except Exception as e:
+        _store_failure_info(service_config_id, e)
+
+
+class MsTeamsBackend(BaseWebhookBackend):
+    def __init__(self, service_config):
+        self.service_config = service_config
+
+    @classmethod
+    def get_form_class(cls):
+        return MsTeamsConfigForm
+
+    def send_test_message(self):
+        config = json.loads(self.service_config.config)
+        msteams_backend_send_test_message.delay(
+            config["webhook_url"],
+            self.service_config.project.name,
+            self.service_config.display_name,
+            self.service_config.id,
+        )
+
+    def send_alert(self, issue_id, state_description, alert_article, alert_reason, **kwargs):
+        config = json.loads(self.service_config.config)
+        msteams_backend_send_alert.delay(
+            config["webhook_url"],
+            issue_id,
+            state_description,
+            alert_article,
+            alert_reason,
+            self.service_config.id,
+            **kwargs,
+        )

--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -21,6 +21,8 @@ from .service_backends.slack import slack_backend_send_test_message, slack_backe
 from .service_backends.discord import discord_backend_send_test_message, discord_backend_send_alert
 from .service_backends.discord import DiscordConfigForm
 from .service_backends.mattermost import MattermostConfigForm
+from .service_backends.msteams import msteams_backend_send_test_message, msteams_backend_send_alert
+from .service_backends.msteams import MsTeamsConfigForm
 from .service_backends.slack import SlackConfigForm
 from .service_backends.telegram import (
     MASKED,
@@ -898,6 +900,91 @@ class TestCustomBackendErrorHandling(DjangoTestCase):
         self.assertFalse(self.config.has_recent_failure())
 
 
+class TestMsTeamsBackend(DjangoTestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test project")
+        self.config = MessagingServiceConfig.objects.create(
+            project=self.project,
+            display_name="Test Teams",
+            kind="msteams",
+            config=json.dumps({"webhook_url": "https://example.logic.azure.com/workflows/test"}),
+        )
+
+    def _get_card(self, mock_post):
+        data = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(data["type"], "message")
+        attachment = data["attachments"][0]
+        self.assertEqual(attachment["contentType"], "application/vnd.microsoft.card.adaptive")
+        return attachment["content"]
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_msteams_test_message_sends_adaptive_card(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        msteams_backend_send_test_message(
+            "https://example.logic.azure.com/workflows/test",
+            "Test project",
+            "Test Teams",
+            self.config.id,
+        )
+
+        card = self._get_card(mock_post)
+        self.assertEqual(card["type"], "AdaptiveCard")
+        self.assertEqual(card["body"][0]["text"], "TEST issue")
+
+        self.config.refresh_from_db()
+        self.assertIsNone(self.config.last_failure_timestamp)
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_msteams_alert_links_to_issue(self, mock_post):
+        issue, _ = get_or_create_issue(project=self.project)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        msteams_backend_send_alert(
+            "https://example.logic.azure.com/workflows/test",
+            issue.id,
+            "New issue",
+            "a",
+            "NEW",
+            self.config.id,
+        )
+
+        card = self._get_card(mock_post)
+        self.assertEqual(card["actions"][0]["type"], "Action.OpenUrl")
+        self.assertTrue(card["actions"][0]["url"].endswith(issue.get_absolute_url()))
+        self.assertEqual(card["body"][-1]["facts"], [{"title": "project", "value": "Test project"}])
+
+    @patch('alerts.service_backends.base.BaseWebhookBackend.safe_post')
+    def test_msteams_test_message_http_error_stores_failure(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = 'Not Found'
+
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        mock_post.return_value = mock_response
+
+        msteams_backend_send_test_message(
+            "https://example.logic.azure.com/workflows/test",
+            "Test project",
+            "Test Teams",
+            self.config.id,
+        )
+
+        self.config.refresh_from_db()
+        self.assertIsNotNone(self.config.last_failure_timestamp)
+        self.assertEqual(self.config.last_failure_status_code, 404)
+        self.assertEqual(self.config.last_failure_error_type, "HTTPError")
+
 class TestWebhookSecurityValidation(DjangoTestCase):
     def test_safe_post_does_not_re_resolve_after_validation(self):
         original_getaddrinfo = socket.getaddrinfo
@@ -1058,6 +1145,21 @@ class TestWebhookConfigForms(DjangoTestCase):
     def test_discord_form_accepts_public_target(self, mock_resolve):
         mock_resolve.return_value = {"93.184.216.34"}
         form = DiscordConfigForm(data={"webhook_url": "https://discord.com/api/webhooks/test"})
+
+        self.assertTrue(form.is_valid())
+
+    def test_msteams_form_rejects_blocked_target(self):
+        form = MsTeamsConfigForm(data={"webhook_url": "http://10.0.0.42/workflows/test"})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("non-global IP address", form.errors["webhook_url"][0])
+
+    @patch("alerts.service_backends.webhook_security._resolve_ip_addresses")
+    def test_msteams_form_accepts_long_workflow_url(self, mock_resolve):
+        mock_resolve.return_value = {"93.184.216.34"}
+        form = MsTeamsConfigForm(data={
+            "webhook_url": "https://prod-1.westeurope.logic.azure.com:443/workflows/" + ("a" * 300),
+        })
 
         self.assertTrue(form.is_valid())
 


### PR DESCRIPTION
Teams alerts go out as an Adaptive Card wrapped in a message attachment, which is the format the Power Automate "Workflows" webhooks expect. The older Office 365 Connectors, which take a MessageCard instead, are deliberately not supported: Microsoft has retired them, so building on that format would start out deprecated.