### PR TITLE
Fix project creation by showing the grouping mechanism field

### DIFF
--- a/projects/templates/projects/project_new.html
+++ b/projects/templates/projects/project_new.html
@@ -22,6 +22,7 @@
         {% tailwind_formfield form.name %}
         {% tailwind_formfield form.visibility %}
         {% tailwind_formfield form.retention_max_event_count %}
+        {% tailwind_formfield form.grouping_mechanism %}
 
         <button name="action" value="invite" class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-md">{% translate "Save" %}</button>
         <a href="{% url "project_list" %}" class="text-cyan-500 dark:text-cyan-300 font-bold ml-2">{% translate "Cancel" %}</a>


### PR DESCRIPTION
Creating a project silently did nothing: clicking Save returned the same form with no error message anywhere on the page, and no project was created. Editing a project worked fine.