### PR TITLE
Unify page heading format across project/team/settings pages

### DIFF
--- a/issues/templates/issues/issue_list.html
+++ b/issues/templates/issues/issue_list.html
@@ -37,7 +37,7 @@
 {% endif %}
 
 <div class="m-4">
-<h1 class="text-4xl mt-4 font-bold">{% if project %}{{ project.name }} - {% endif %}{% translate "Issues" %}</h1>
+<h1 class="text-4xl mt-4 font-bold">{% translate "Issues" %}{% if project %} · {{ project.name }}{% endif %}</h1>
 
 
 {% if unapplied_issue_ids %}

--- a/projects/templates/projects/project_alerts_setup.html
+++ b/projects/templates/projects/project_alerts_setup.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 
-{% block title %}{% translate "Alerts" %} · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Alerts" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -22,7 +22,7 @@
         {% endif %}
 
         <div class="flex">
-            <h1 class="text-4xl mt-4 font-bold">{{ project.name }} · {% translate "Alerts" %}</h1>
+            <h1 class="text-4xl mt-4 font-bold">{% translate "Alerts" %} · {{ project.name }}</h1>
 
             <div class="ml-auto mt-6">
                 <a class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-md" href="{% url "project_messaging_service_add" project_pk=project.pk %}">{% translate "Add" %}</a>

--- a/projects/templates/projects/project_edit.html
+++ b/projects/templates/projects/project_edit.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}{% translate "Edit" %} {{ project.name }} · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Settings" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -35,7 +35,7 @@
         {% csrf_token %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% blocktranslate with project_name=project.name %}Settings ({{ project_name }}){% endblocktranslate %}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Settings" %} · {{ project.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/projects/templates/projects/project_member_settings.html
+++ b/projects/templates/projects/project_member_settings.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}{% translate "Member settings" %} · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Membership settings" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -24,7 +24,7 @@
         {% endif %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% translate "Membership settings" %}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Membership settings" %} · {{ project.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/projects/templates/projects/project_members.html
+++ b/projects/templates/projects/project_members.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 
-{% block title %}Members · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Members" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -24,7 +24,7 @@
         {% include "includes/invite_link_notice.html" %}
 
         <div class="flex">
-            <h1 class="text-4xl mt-4 font-bold">{% translate "Project Members" %}</h1>
+            <h1 class="text-4xl mt-4 font-bold">{% translate "Members" %} · {{ project.name }}</h1>
 
             <div class="ml-auto mt-6">
                 <a class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-md" href="{% url "project_members_invite" project_pk=project.pk %}">{% translate "Invite Member" %}</a>

--- a/projects/templates/projects/project_members_accept.html
+++ b/projects/templates/projects/project_members_accept.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 
-{% block title %}Invitation · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Invitation" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -15,7 +15,7 @@
         {% csrf_token %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% translate "Invitation to" %} "{{ project.name }}"</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Invitation" %} · {{ project.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/projects/templates/projects/project_members_invite.html
+++ b/projects/templates/projects/project_members_invite.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}Invite Members · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Invite members" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -25,7 +25,7 @@
         {% include "includes/invite_link_notice.html" %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% blocktranslate with project_name=project.name %}Invite members ({{ project_name }}){% endblocktranslate %}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Invite members" %} · {{ project.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/projects/templates/projects/project_messaging_service_edit.html
+++ b/projects/templates/projects/project_messaging_service_edit.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% load tailwind_forms %}
+{% load i18n %}
 
-{% block title %}Messaging Service · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Messaging Service" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -22,7 +23,7 @@
         {% endif %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">Messaging Service | {{ project.name }}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Messaging Service" %} · {{ project.name }}</h1>
         </div>
 
         {% if service_config.has_recent_failure %}

--- a/projects/templates/projects/project_messaging_service_new.html
+++ b/projects/templates/projects/project_messaging_service_new.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% load tailwind_forms %}
+{% load i18n %}
 
-{% block title %}Messaging Service · {{ project.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Messaging Service" %} · {{ project.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -22,7 +23,7 @@
         {% endif %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">Messaging Service | {{ project.name }}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Messaging Service" %} · {{ project.name }}</h1>
         </div>
 
         {% for field in form %}

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -60,7 +60,7 @@ class ProjectInviteLinkTestCase(TransactionTestCase):
             "No invitation was sent because email is not set up. "
             "Hand out the following link to new-project-member@example.com yourself:",
         )
-        self.assertContains(response, "Project Members")
+        self.assertContains(response, f"Members · {self.project.name}")
         self.assertContains(response, reverse("project_members_accept_new_user", kwargs={
             "project_pk": self.project.pk,
             "token": verification.token,

--- a/teams/templates/teams/team_edit.html
+++ b/teams/templates/teams/team_edit.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}{% translate "Edit" %} {{ team.name }} · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Settings" %} · {{ team.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -15,7 +15,7 @@
         {% csrf_token %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% blocktranslate with team_name=team.name %}Settings ({{ team_name }}){% endblocktranslate %}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Settings" %} · {{ team.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/teams/templates/teams/team_member_settings.html
+++ b/teams/templates/teams/team_member_settings.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}Member settings · {{ team.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Membership settings" %} · {{ team.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -24,7 +24,7 @@
         {% endif %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{% trans "Membership settings" %}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% trans "Membership settings" %} · {{ team.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/teams/templates/teams/team_members.html
+++ b/teams/templates/teams/team_members.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 
-{% block title %}{% translate "Members" %} · {{ team.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Members" %} · {{ team.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -24,7 +24,7 @@
         {% include "includes/invite_link_notice.html" %}
 
         <div class="flex">
-            <h1 class="text-4xl mt-4 font-bold">{% translate "Team Members" %}</h1>
+            <h1 class="text-4xl mt-4 font-bold">{% translate "Members" %} · {{ team.name }}</h1>
 
             <div class="ml-auto mt-6">
                 <a class="font-bold text-slate-800 dark:text-slate-100 border-slate-500 dark:border-slate-400 pl-4 pr-4 pb-2 pt-2 ml-1 border-2 bg-cyan-200 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 active:ring-3 rounded-md" href="{% url "team_members_invite" team_pk=team.pk %}">{% translate "Invite Member" %}</a>

--- a/teams/templates/teams/team_members_accept.html
+++ b/teams/templates/teams/team_members_accept.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
-{% block title %}Invitation · {{ team.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Invitation" %} · {{ team.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -14,7 +15,7 @@
         {% csrf_token %}
 
         <div>
-            <h1 class="text-4xl mt-4 font-bold">Invitation to "{{ team.name }}"</h1>
+            <h1 class="text-4xl mt-4 font-bold">{% translate "Invitation" %} · {{ team.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/teams/templates/teams/team_members_invite.html
+++ b/teams/templates/teams/team_members_invite.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}Invite Members · {{ team.name }}  · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Invite members" %} · {{ team.name }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 
@@ -27,7 +27,7 @@
         {% include "includes/invite_link_notice.html" %}
 
         <div>
-            <h1 class="text-4xl mt-4 font-bold">{% blocktranslate with team_name=team.name %}Invite members ({{ team_name }}){% endblocktranslate %}</h1>
+            <h1 class="text-4xl mt-4 font-bold">{% translate "Invite members" %} · {{ team.name }}</h1>
         </div>
 
         <div class="mt-4 mb-4">

--- a/teams/templates/teams/team_new.html
+++ b/teams/templates/teams/team_new.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}New team  · {{ site_title }}{% endblock %}
+{% block title %}New team · {{ site_title }}{% endblock %}
 
 {% block content %}
 

--- a/teams/tests.py
+++ b/teams/tests.py
@@ -40,7 +40,7 @@ class TeamInviteLinkTestCase(TransactionTestCase):
             "No invitation was sent because email is not set up. "
             "Hand out the following link to new-team-member@example.com yourself:",
         )
-        self.assertContains(response, "Team Members")
+        self.assertContains(response, f"Members · {self.team.name}")
         self.assertContains(response, reverse("team_members_accept_new_user", kwargs={
             "team_pk": self.team.pk,
             "token": verification.token,

--- a/users/templates/users/user_edit.html
+++ b/users/templates/users/user_edit.html
@@ -3,7 +3,7 @@
 {% load tailwind_forms %}
 {% load i18n %}
 
-{% block title %}{% translate "Edit" %} {{ form.instance.username }} · {{ site_title }}{% endblock %}
+{% block title %}{% translate "Edit" %} · {{ form.instance.username }} · {{ site_title }}{% endblock %}
 
 {% block content %}
 

--- a/users/templates/users/user_edit.html
+++ b/users/templates/users/user_edit.html
@@ -15,7 +15,7 @@
         {% csrf_token %}
 
         <div>
-            <h1 class="text-4xl my-4 font-bold">{{ form.instance.username }}</h1>
+            <h1 class="text-4xl my-4 font-bold">{% translate "Edit" %} · {{ form.instance.username }}</h1>
         </div>
 
         <div class="mt-4 mb-4">


### PR DESCRIPTION
Page h1 headings on settings, alerts, and membership pages were each rendered independently (no shared block in the layout), so four different separators and orderings ended up side by side: "Settings (test)", "test · Alerts", "test - Issues", "Messaging Service | test".

Unified them to a single "Section · Name" pattern (e.g. "Settings · test", "Alerts · test", "Members · test"), matching the convention that already dominated the <title> tags across the app.