### PR TITLE
Show stacktrace from the first thread from the "threads" interface if no exception exist

### DIFF
--- a/events/markdown_stacktrace.py
+++ b/events/markdown_stacktrace.py
@@ -12,7 +12,7 @@
 
 import logging
 from django.conf import settings
-from events.utils import apply_sourcemaps
+from events.utils import apply_sourcemaps, get_stacktrace_entries
 
 from sentry_sdk_extensions import capture_or_log_exception
 
@@ -40,17 +40,6 @@ def _code_lines(frame):
         lines.append(ctx)
     lines.extend(post)
     return lines
-
-
-def _iter_exceptions(parsed):
-    exc = parsed.get("exception")
-    if not exc:
-        return []
-    if isinstance(exc, dict):
-        return list(exc.get("values") or [])
-    if isinstance(exc, (list, tuple)):
-        return list(exc)
-    return []
 
 
 def _frames_for_exception(exc):
@@ -145,7 +134,7 @@ def render_stacktrace_md(event, in_app_only=False, include_locals=True):
         # sourcemaps are still experimental; we don't want to fail on them, so we just log the error and move on.
         capture_or_log_exception(e, logger)
 
-    excs = _iter_exceptions(parsed)
+    excs = get_stacktrace_entries(parsed)
     if not excs:
         return "_No stacktrace available._"
 

--- a/events/test_thread_stacktraces.py
+++ b/events/test_thread_stacktraces.py
@@ -38,6 +38,9 @@ THREAD_STACKTRACE_SAMPLES = [
     ),
 ]
 
+JAVA_MULTIPLE_THREADS_SAMPLE = "sentry-java-capture-message-attach-threads.json"
+JAVA_MULTIPLE_THREADS_MESSAGE = "capture_message with all Java threads from ProbeMultipleThreads.java"
+
 
 def load_generated_sample(filename):
     with open(GENERATED_SAMPLES_DIR / filename) as sample:
@@ -105,3 +108,24 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
                 response = self.api_client.get(reverse("api:event-stacktrace", args=[event.id]))
                 self.assertEqual(200, response.status_code)
                 self.assertEqual(markdown, response.content.decode())
+
+    def test_multiple_threads_render_the_first_stacktrace_with_frames(self):
+        data = load_generated_sample(JAVA_MULTIPLE_THREADS_SAMPLE)
+        event = create_event(project=self.project, event_data=data, platform=data["platform"])
+
+        entries = get_stacktrace_entries(data)
+        self.assertEqual(1, len(entries))
+        self.assertEqual(data["threads"]["values"][1]["stacktrace"], entries[0]["stacktrace"])
+        self.assertEqual("Log Message", entries[0]["type"])
+        self.assertEqual(JAVA_MULTIPLE_THREADS_MESSAGE, entries[0]["value"])
+
+        response = self.client.get(f"/issues/issue/{event.issue.id}/event/{event.id}/")
+        self.assertContains(response, JAVA_MULTIPLE_THREADS_MESSAGE)
+        self.assertContains(response, "ProbeMultipleThreads.java")
+        self.assertNotContains(response, "bugsink-probe-background")
+        self.assertNotContains(response, "No stacktrace available for this event.")
+
+        markdown = render_stacktrace_md(event)
+        self.assertIn(JAVA_MULTIPLE_THREADS_MESSAGE, markdown)
+        self.assertIn("ProbeMultipleThreads.java", markdown)
+        self.assertNotIn("bugsink-probe-background", markdown)

--- a/events/test_thread_stacktraces.py
+++ b/events/test_thread_stacktraces.py
@@ -1,0 +1,107 @@
+import json
+import os
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.test import tag
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from bsmain.models import AuthToken
+from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
+from projects.models import Project, ProjectMembership
+
+from .factories import create_event
+from .markdown_stacktrace import render_stacktrace_md
+from .serializers import EventDetailSerializer
+from .utils import get_stacktrace_entries
+
+
+SAMPLES_DIR = Path(os.getenv("SAMPLES_DIR", "../event-samples"))
+GENERATED_SAMPLES_DIR = SAMPLES_DIR / "generated"
+
+THREAD_STACKTRACE_SAMPLES = [
+    (
+        "sentry-python-capture-message-attach-stacktrace.json",
+        "capture_message attach_stacktrace from probe_capture_message.py",
+        "probe_capture_message.py",
+    ),
+    (
+        "sentry-python-logger-error-attach-stacktrace.json",
+        "plain logger.error attach_stacktrace from probe_logger_error.py",
+        "probe_logger_error.py",
+    ),
+    (
+        "sentry-python-logger-error-stack-info.json",
+        "logger.error stack_info from probe_logger_error_stack_info.py",
+        "probe_logger_error_stack_info.py",
+    ),
+]
+
+
+def load_generated_sample(filename):
+    with open(GENERATED_SAMPLES_DIR / filename) as sample:
+        return json.load(sample)
+
+
+@tag("samples")
+class ThreadStacktraceSampleTests(TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = get_user_model().objects.create_user(username="test")
+        self.project = Project.objects.create(name="Thread stacktrace samples")
+        ProjectMembership.objects.create(project=self.project, user=self.user, accepted=True)
+        self.client.force_login(self.user)
+        self.api_client = APIClient()
+        token = AuthToken.objects.create()
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+
+    def test_capture_exception_uses_its_exception_stacktrace(self):
+        data = load_generated_sample("sentry-python-capture-exception-add-full-stack.json")
+
+        entries = get_stacktrace_entries(data)
+
+        self.assertEqual(1, len(entries))
+        self.assertEqual("RuntimeError", entries[0]["type"])
+        self.assertTrue(entries[0]["is_exception_stacktrace"])
+        self.assertEqual(3, len(entries[0]["stacktrace"]["frames"]))
+
+    def test_thread_stacktrace_samples_render_the_log_message(self):
+        for filename, message, probe_filename in THREAD_STACKTRACE_SAMPLES:
+            with self.subTest(filename=filename):
+                data = load_generated_sample(filename)
+                event = create_event(project=self.project, event_data=data, platform=data["platform"])
+
+                entries = get_stacktrace_entries(data)
+                self.assertEqual(1, len(entries))
+                self.assertEqual("Log Message", entries[0]["type"])
+                self.assertEqual(message, entries[0]["value"])
+                self.assertFalse(entries[0]["is_exception_stacktrace"])
+
+                response = self.client.get(f"/issues/issue/{event.issue.id}/event/{event.id}/")
+                self.assertContains(response, "Log Message")
+                self.assertContains(response, message)
+                self.assertContains(response, probe_filename)
+                self.assertNotContains(response, "capture point")
+                self.assertNotContains(response, "raise Log Message")
+                self.assertNotContains(response, "\u2192 begin")
+                self.assertNotContains(response, "Thread 1")
+                self.assertNotContains(response, "No stacktrace available for this event.")
+
+                markdown = render_stacktrace_md(event)
+                self.assertIn("# Log Message", markdown)
+                self.assertIn(message, markdown)
+                self.assertIn(probe_filename, markdown)
+                self.assertNotIn("Thread 1", markdown)
+                self.assertNotEqual("_No stacktrace available._", markdown)
+
+                detail = EventDetailSerializer(event).data
+                self.assertEqual(markdown, detail["stacktrace_md"])
+
+                response = self.api_client.get(reverse("api:event-detail", args=[event.id]))
+                self.assertEqual(200, response.status_code)
+                self.assertEqual(markdown, response.json()["stacktrace_md"])
+
+                response = self.api_client.get(reverse("api:event-stacktrace", args=[event.id]))
+                self.assertEqual(200, response.status_code)
+                self.assertEqual(markdown, response.content.decode())

--- a/events/utils.py
+++ b/events/utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 import json
 import ecma426
-from issues.utils import get_values
+from issues.utils import get_type_and_value_for_data, get_values
 
 from bugsink.transaction import delay_on_commit
 from bugsink.utils import assert_
@@ -17,6 +17,36 @@ from files.tasks import record_file_accesses
 # Dijkstra, sourcemaps and Python lists start at 0, but sentry-event frames, editors and our UI (lines/cols) start at 1.
 FROM_DISPLAY = -1
 TO_DISPLAY = 1
+
+
+def get_stacktrace_entries(event_data):
+    exceptions = get_values(event_data.get("exception"))
+    if exceptions:
+        # Exception Stacktrace entries are preferred over thread stacktrace entries, so if we have any exceptions, we
+        # ignore the threads.
+        return [dict(exception, is_exception_stacktrace=True) for exception in exceptions]
+
+    threads = get_values(event_data.get("threads"))
+    if not threads:
+        return []  # The threads interface is optional.
+
+    if len(threads) != 1:
+        return []  # Current evidence only covers the single-thread shape.
+
+    stacktrace = threads[0].get("stacktrace")
+    if not stacktrace:
+        return []  # The stacktrace interface is optional within threads.
+
+    if not stacktrace.get("frames"):
+        return []  # Illegal in API, but as observed sample: exception_null_frames.json
+
+    type_, value = get_type_and_value_for_data(event_data)
+    return [{
+        "type": type_,
+        "value": value,
+        "stacktrace": stacktrace,
+        "is_exception_stacktrace": False,
+    }]
 
 
 class IncompleteList(list):

--- a/events/utils.py
+++ b/events/utils.py
@@ -30,15 +30,17 @@ def get_stacktrace_entries(event_data):
     if not threads:
         return []  # The threads interface is optional.
 
-    if len(threads) != 1:
-        return []  # Current evidence only covers the single-thread shape.
+    for thread in threads:
+        stacktrace = thread.get("stacktrace")
+        if not stacktrace:
+            continue  # The stacktrace interface is optional within threads.
 
-    stacktrace = threads[0].get("stacktrace")
-    if not stacktrace:
-        return []  # The stacktrace interface is optional within threads.
+        if not stacktrace.get("frames"):
+            continue  # Illegal in API, but as observed sample: exception_null_frames.json
 
-    if not stacktrace.get("frames"):
-        return []  # Illegal in API, but as observed sample: exception_null_frames.json
+        break  # found a thread with a stacktrace; use it.
+    else:
+        return []
 
     type_, value = get_type_and_value_for_data(event_data)
     return [{

--- a/issues/templates/issues/stacktrace.html
+++ b/issues/templates/issues/stacktrace.html
@@ -94,6 +94,7 @@
                 </div>
 
                 <div class="ml-auto pr-4">{# indicator for frame's position in stacktrace #}
+                    {% if exception.is_exception_stacktrace %}
                     {% if stack_of_plates and forloop.first or not stack_of_plates and forloop.last %}
                         {% if stack_of_plates and forloop.parentloop.first or not stack_of_plates and forloop.parentloop.last %}
                             <span class="bg-slate-200 dark:bg-slate-800 pl-2 pr-2 pt-1 pb-1 rounded-md whitespace-nowrap">raise {{ exception.type }}</span>
@@ -117,6 +118,7 @@
                             <span class="bg-slate-200 dark:bg-slate-800 pl-2 pr-2 pt-1 pb-1 rounded-md whitespace-nowrap">try…</span>
                         {% endif %}
 
+                    {% endif %}
                     {% endif %}
                 </div>
 

--- a/issues/views.py
+++ b/issues/views.py
@@ -36,7 +36,7 @@ from .models import (
     apply_issue_action, is_valid_issue_action, q_for_invalid_issue_action)
 from .forms import CommentForm
 from .utils import get_values, get_main_exception
-from events.utils import annotate_with_meta, apply_sourcemaps, get_sourcemap_images
+from events.utils import annotate_with_meta, apply_sourcemaps, get_sourcemap_images, get_stacktrace_entries
 from .markdown_issue import render_issue_md
 from .grouping_mechanisms import GROUPING_MECHANISMS, MECHANISM_INDEPENDENT_GROUPING
 
@@ -416,7 +416,7 @@ def issue_event_stacktrace(request, issue, event_pk=None, digest_order=None, nav
 
     parsed_data = event.get_parsed_data()
 
-    exceptions = get_values(parsed_data["exception"]) if "exception" in parsed_data else None
+    exceptions = get_stacktrace_entries(parsed_data)
 
     try:
         # get_values for consistency (whether it's needed: unclear, since _meta is not actually in the specs)
@@ -445,7 +445,7 @@ def issue_event_stacktrace(request, issue, event_pk=None, digest_order=None, nav
     # (possibly later) have this as something that is configurable at the user level.
     stack_of_plates = event.platform != "python"  # Python is the only platform that has chronological stacktraces
 
-    if exceptions is not None and len(exceptions) > 0:
+    if exceptions:
         if exceptions[-1].get('stacktrace') and exceptions[-1]['stacktrace'].get('frames'):
             exceptions[-1]['stacktrace']['frames'][-1]['raise_point'] = True
 

--- a/sentry_sdk_extensions/__init__.py
+++ b/sentry_sdk_extensions/__init__.py
@@ -5,36 +5,20 @@ import sentry_sdk
 
 
 def capture_stacktrace(message):
-    """
-    Capture the current stacktrace and send it to Sentry _as an CapturedStacktrace with stacktrace context; the standard
-    sentry_sdk does not provide this; it either allows for sending arbitrary messages (but without local variables on
-    your stacktrace) or it allows for sending exceptions (but you have to raise an exception to capture the stacktrace).
-    """
-    # with capture_internal_exceptions():   commented out; I'd rather see the exception than swallow it
-
-    # client_options = sentry_sdk.client.get_options()
-    # client_options["include_local_variables"]  for this and other parameters to current_stacktrace to
-    # current_stacktrace() I'm just going to accept the default values. The default values are fine _to me_ and I'm not
-    # in the business of developing a generic set of sentry_sdk_extensions, but rather to have a few extensions that are
-    # useful in the context of developing Bugsink, and having another Bugsink to send those to.
-    # (The reason not to parse client_options is: Sentry might change their names and I don't want the maintenance)
+    """Capture the current stacktrace as an error-level log message."""
     stacktrace = current_stacktrace()
     stacktrace["frames"].pop()  # Remove the last frame, which is the present function
 
     event = {
-        'level': 'error',
-        'exception': {
-            'values': [{
-                'mechanism': {
-                    'type': 'generic',
-                    'handled': True
-                },
-                'module': stacktrace["frames"][-1]["module"],
-                'type': 'CapturedStacktrace',
-                'value': message,
-                'stacktrace': stacktrace,
+        "level": "error",
+        "logentry": {"message": message},
+        "threads": {
+            "values": [{
+                "stacktrace": stacktrace,
+                "crashed": False,
+                "current": True,
             }]
-        }
+        },
     }
     sentry_sdk.capture_event(event)
 


### PR DESCRIPTION
This is useful e.g. for the case where a log message has an attached stacktrace.