### PR TITLE
Remove plain-text event view

### DIFF
--- a/events/templates/events/event_stacktrace.txt
+++ b/events/templates/events/event_stacktrace.txt
@@ -1,6 +1,0 @@
-{% autoescape off %}Traceback (most recent call last):{% for exception in exceptions %}{% for frame in exception.stacktrace.frames %}
-  File {{ frame.filename }}, line {{ frame.lineno }}{% if frame.function %}, in {{ frame.function }}{% endif %}
-    {{ frame.context_line.strip }}{% endfor %}{% if not forloop.last %}
-
-During handling of the above exception another exception occurred or was intentionally reraised:{% endif %}
-{% endfor %}{% endautoescape %}

--- a/events/tests.py
+++ b/events/tests.py
@@ -54,17 +54,12 @@ class ViewTests(TransactionTestCase):
         self.assertEqual(response['Content-Type'], 'application/json')
         self.assertTrue("platform" in response.json())
 
-    def test_event_plaintext(self):
-        response = self.client.get(f"/events/event/{self.event.pk}/plain/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Type'], 'text/plain')
-
     def test_event_views_forbid_events_from_other_projects(self):
         other_project = Project.objects.create(name="other")
         other_issue, _ = get_or_create_issue(project=other_project)
         other_event = create_event(other_project, other_issue)
 
-        for suffix in ["download/", "raw/", "plain/", "md/"]:
+        for suffix in ["download/", "raw/", "md/"]:
             with self.subTest(suffix=suffix):
                 response = self.client.get(f"/events/event/{other_event.pk}/{suffix}")
                 self.assertEqual(response.status_code, 403)

--- a/events/urls.py
+++ b/events/urls.py
@@ -1,12 +1,11 @@
 from django.urls import path
 
-from .views import event_download, event_plaintext, event_markdown
+from .views import event_download, event_markdown
 
 
 urlpatterns = [
     # path('event/<uuid:pk>/', event_detail),  perhaps should become a redirect to issue/.../event now?
     path('event/<uuid:event_pk>/raw/', event_download, kwargs={"as_attachment": False}),
     path('event/<uuid:event_pk>/download/', event_download, kwargs={"as_attachment": True}),
-    path('event/<uuid:event_pk>/plain/', event_plaintext),
     path('event/<uuid:event_pk>/md/', event_markdown),
 ]

--- a/events/views.py
+++ b/events/views.py
@@ -1,9 +1,7 @@
 from django.http import HttpResponse
 from django.utils.http import content_disposition_header
-from django.shortcuts import render
 
 from bugsink.decorators import event_membership_required, atomic_for_request_method
-from issues.utils import get_values
 
 from .markdown_stacktrace import render_stacktrace_md
 
@@ -15,18 +13,6 @@ def event_download(request, event, as_attachment=False):
     result["Content-Disposition"] = content_disposition_header(
         as_attachment=as_attachment, filename=event.id.hex + ".json")
     return result
-
-
-@atomic_for_request_method
-@event_membership_required
-def event_plaintext(request, event):
-    parsed_data = event.get_parsed_data()
-    exceptions = get_values(parsed_data["exception"]) if "exception" in parsed_data else None
-
-    return render(request, "events/event_stacktrace.txt", {
-        "event": event,
-        "exceptions": exceptions,
-    }, content_type="text/plain")
 
 
 @atomic_for_request_method

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -122,7 +122,6 @@
                 <a href="{{ script_prefix }}/events/event/{{ event.id }}/download/">{% translate "Download" %}</a>
                 | <a href="{{ script_prefix }}/events/event/{{ event.id }}/raw/" >{% translate "JSON" %}</a>
                 | <a href="{{ script_prefix }}/events/event/{{ event.id }}/md/" >{% translate "Markdown" %}</a>
-                | <a href="{{ script_prefix }}/events/event/{{ event.id }}/plain/" >{% translate "Plain" %}</a>
                 {% endif %}
 
                 {% if app_settings.USE_ADMIN and user.is_staff %}


### PR DESCRIPTION
The Markdown view now completely covers this use case. Keeping the old plain-text renderer takes a toll on the UI and maintains an extra code path, while the renderer itself is Python-specific, broken, and unmaintained.

Remove the link, endpoint, view, template, and associated test coverage.