### PR TITLE
Add support for case-insensitive email handling

### DIFF
--- a/bugsink/app_settings.py
+++ b/bugsink/app_settings.py
@@ -40,7 +40,8 @@ DEFAULTS = {
 
     # if True, emails are lowercased on the way in, which makes them effectively case-insensitive. Default False (i.e.
     # "keep what was typed") for backwards-compatibility; existing instances can switch after running
-    # `manage.py lowercase_user_emails`.
+    # `manage.py lowercase_user_emails`. On MySQL, matching is already case-insensitive by collation; the setting then
+    # only affects the casing that gets stored.
     "USER_EMAIL_CASE_INSENSITIVE": False,
 
     # if True, there is only one team, and all projects are in that team

--- a/bugsink/app_settings.py
+++ b/bugsink/app_settings.py
@@ -38,6 +38,11 @@ DEFAULTS = {
     "USER_REGISTRATION_VERIFY_EMAIL": True,
     "USER_REGISTRATION_VERIFY_EMAIL_EXPIRY": 3 * 24 * 60 * 60,  # 7 days
 
+    # if True, emails are lowercased on the way in, which makes them effectively case-insensitive. Default False (i.e.
+    # "keep what was typed") for backwards-compatibility; existing instances can switch after running
+    # `manage.py lowercase_user_emails`.
+    "USER_EMAIL_CASE_INSENSITIVE": False,
+
     # if True, there is only one team, and all projects are in that team
     "SINGLE_TEAM": False,
     "TEAM_CREATION": CB_MEMBERS,  # who can create new teams. default: members, which means "any member of the site"

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -144,6 +144,7 @@ BUGSINK = {
 
     # if True, emails are lowercased on the way in (signup, invite, login), making them case-insensitive.
     # On existing instances, run `bugsink-manage lowercase_user_emails` before turning this on.
+    # (On MySQL, matching is already case-insensitive by collation; this only affects the casing that gets stored.)
     "USER_EMAIL_CASE_INSENSITIVE": os.getenv("USER_EMAIL_CASE_INSENSITIVE", "False").lower() in ("true", "1", "yes"),
 
     # if True, there is only one team, and all projects are in that team

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -142,6 +142,10 @@ BUGSINK = {
     "USER_REGISTRATION_VERIFY_EMAIL_EXPIRY":
         int(os.getenv("USER_REGISTRATION_VERIFY_EMAIL_EXPIRY", 7 * 24 * 60 * 60)),  # 7 days
 
+    # if True, emails are lowercased on the way in (signup, invite, login), making them case-insensitive.
+    # On existing instances, run `bugsink-manage lowercase_user_emails` before turning this on.
+    "USER_EMAIL_CASE_INSENSITIVE": os.getenv("USER_EMAIL_CASE_INSENSITIVE", "False").lower() in ("true", "1", "yes"),
+
     # if True, there is only one team, and all projects are in that team
     "SINGLE_TEAM": os.getenv("SINGLE_TEAM", "False").lower() in ("true", "1", "yes"),
     "TEAM_CREATION": os.getenv("TEAM_CREATION", CB_MEMBERS),  # who can create new teams.

--- a/bugsink/conf_templates/singleserver.py.template
+++ b/bugsink/conf_templates/singleserver.py.template
@@ -102,6 +102,7 @@ BUGSINK = {
 
     # if True, emails are lowercased on the way in (signup, invite, login), making them case-insensitive.
     # On existing instances, run `bugsink-manage lowercase_user_emails` before turning this on.
+    # (On MySQL, matching is already case-insensitive by collation; this only affects the casing that gets stored.)
     "USER_EMAIL_CASE_INSENSITIVE": False,
 
     # if True, there is only one team, and all projects are in that team

--- a/bugsink/conf_templates/singleserver.py.template
+++ b/bugsink/conf_templates/singleserver.py.template
@@ -100,6 +100,10 @@ BUGSINK = {
     "USER_REGISTRATION_VERIFY_EMAIL": True,
     "USER_REGISTRATION_VERIFY_EMAIL_EXPIRY": 3 * 24 * 60 * 60,  # 7 days
 
+    # if True, emails are lowercased on the way in (signup, invite, login), making them case-insensitive.
+    # On existing instances, run `bugsink-manage lowercase_user_emails` before turning this on.
+    "USER_EMAIL_CASE_INSENSITIVE": False,
+
     # if True, there is only one team, and all projects are in that team
     "SINGLE_TEAM": False,
     "TEAM_CREATION": CB_MEMBERS,  # who can create new teams. default: members, which means "any member of the site"

--- a/bugsink/urls.py
+++ b/bugsink/urls.py
@@ -12,6 +12,7 @@ from alerts.views import debug_email as debug_alerts_email
 from users.views import debug_email as debug_users_email
 from teams.views import debug_email as debug_teams_email
 from bugsink.app_settings import get_settings
+from users.forms import AuthenticationForm
 from users.views import (
     signup, confirm_email, resend_confirmation, request_reset_password, reset_password, preferences, change_password)
 from ingest.views import download_envelope
@@ -54,7 +55,8 @@ urlpatterns = [
     path("accounts/request-reset-password/", request_reset_password, name="request_reset_password"),
     path("accounts/reset-password/<str:token>/", reset_password, name="reset_password"),
 
-    path("accounts/login/", auth_views.LoginView.as_view(template_name="bugsink/login.html"), name="login"),
+    path("accounts/login/", auth_views.LoginView.as_view(
+        template_name="bugsink/login.html", authentication_form=AuthenticationForm), name="login"),
     path("accounts/logout/", auth_views.LogoutView.as_view(template_name="users/logged_out.html"), name="logout"),
 
     path("accounts/preferences/", preferences, name="preferences"),

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -11,6 +11,7 @@ from bugsink.app_settings import get_settings
 from issues.grouping_mechanisms import GROUPING_TRANSITION_PERIOD, get_grouping_mechanism
 from teams.models import TeamMembership
 from bsmain.utils import yesno
+from users.utils import normalize_email
 
 from .models import Project, ProjectMembership, ProjectRole
 
@@ -30,7 +31,7 @@ class ProjectMemberInviteForm(forms.Form):
             self.fields['email'].help_text = "The user must already exist in the system"
 
     def clean_email(self):
-        email = self.cleaned_data['email']
+        email = normalize_email(self.cleaned_data['email'])
 
         if self.user_must_exist and not User.objects.filter(email=email).exists():
             raise forms.ValidationError('No user with this email address in the system.')

--- a/teams/forms.py
+++ b/teams/forms.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from bugsink.utils import assert_
 from bsmain.utils import yesno
+from users.utils import normalize_email
 from .models import TeamRole, TeamMembership, Team
 
 User = get_user_model()
@@ -21,7 +22,7 @@ class TeamMemberInviteForm(forms.Form):
             self.fields['email'].help_text = "The user must already exist in the system"
 
     def clean_email(self):
-        email = self.cleaned_data['email']
+        email = normalize_email(self.cleaned_data['email'])
 
         if self.user_must_exist and not User.objects.filter(email=email).exists():
             raise forms.ValidationError('No user with this email address in the system.')

--- a/users/apps.py
+++ b/users/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class UsersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'users'
+
+    def ready(self):
+        from . import checks  # noqa: F401
+

--- a/users/checks.py
+++ b/users/checks.py
@@ -1,0 +1,31 @@
+from django.core.checks import Error, register
+from django.contrib.auth import get_user_model
+from django.db import connection
+
+from bugsink.app_settings import get_settings
+
+
+@register("users")
+def check_emails_are_lowercase(app_configs, **kwargs):
+    """USER_EMAIL_CASE_INSENSITIVE lowercases emails on the way in; pre-existing mixed-case users can no longer log
+    in (nor reset their password) until their stored username is lowercased too."""
+
+    if not get_settings().USER_EMAIL_CASE_INSENSITIVE:
+        return []
+
+    User = get_user_model()
+    if User._meta.db_table not in connection.introspection.table_names():
+        return []  # not migrated yet; there are no users to be locked out
+
+    usernames = [u for u in User.objects.values_list("username", flat=True) if u != u.lower()]
+    if not usernames:
+        return []
+
+    examples = ", ".join(sorted(usernames)[:3]) + (", ..." if len(usernames) > 3 else "")
+    return [Error(
+        f"USER_EMAIL_CASE_INSENSITIVE is on, but {len(usernames)} user(s) still have a mixed-case email "
+        f"({examples}). They cannot log in or reset their password. Run 'bugsink-manage lowercase_user_emails' "
+        f"(or turn the setting back off).",
+        id="users.E001",
+    )]
+

--- a/users/checks.py
+++ b/users/checks.py
@@ -13,6 +13,11 @@ def check_emails_are_lowercase(app_configs, **kwargs):
     if not get_settings().USER_EMAIL_CASE_INSENSITIVE:
         return []
 
+    if connection.vendor == "mysql":
+        # MySQL's default collation is case-insensitive, so mixed-case users match on login anyway; nobody is locked
+        # out and the setting only affects the casing of newly stored emails.
+        return []
+
     User = get_user_model()
     if User._meta.db_table not in connection.introspection.table_names():
         return []  # not migrated yet; there are no users to be locked out

--- a/users/forms.py
+++ b/users/forms.py
@@ -2,7 +2,9 @@ import urllib.parse
 
 from django import forms
 from django.urls import reverse
-from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm, SetPasswordForm as BaseSetPasswordForm
+from django.contrib.auth.forms import (
+    AuthenticationForm as BaseAuthenticationForm, UserCreationForm as BaseUserCreationForm,
+    SetPasswordForm as BaseSetPasswordForm)
 from django.core.validators import EmailValidator
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -10,6 +12,8 @@ from django.contrib.auth import password_validation
 from django.forms import ModelForm
 from django.utils.html import escape, mark_safe
 from django.utils.translation import gettext_lazy as _
+
+from .utils import normalize_email
 
 
 TRUE_FALSE_CHOICES = (
@@ -47,12 +51,13 @@ class UserCreationForm(BaseUserCreationForm):
         fields = ("username",)
 
     def clean_username(self):
-        if User.objects.filter(username=self.cleaned_data['username'], is_active=False).exists():
+        username = normalize_email(self.cleaned_data['username'])
+        if User.objects.filter(username=username, is_active=False).exists():
             raise ValidationError(mark_safe(
                 'This email is already registered but not yet confirmed. Please check your email for the confirmation '
                 'link or <b><a href="' + reverse("resend_confirmation") + "?email=" +
-                urllib.parse.quote(escape(self.cleaned_data['username'])) + '">request it again</a></b>.'))
-        return self.cleaned_data['username']
+                urllib.parse.quote(escape(username)) + '">request it again</a></b>.'))
+        return username
 
     def _post_clean(self):
         # copy of django.contrib.auth.forms.UserCreationForm._post_clean; but with password1 instead of password2; I'd
@@ -92,9 +97,10 @@ class UserEditForm(ModelForm):
         fields = ("username",)
 
     def clean_username(self):
-        if User.objects.exclude(pk=self.instance.pk).filter(username=self.cleaned_data['username']).exists():
+        username = normalize_email(self.cleaned_data['username'])
+        if User.objects.exclude(pk=self.instance.pk).filter(username=username).exists():
             raise ValidationError(mark_safe("This email is already registered by another user."))
-        return self.cleaned_data['username']
+        return username
 
     def save(self, **kwargs):
         commit = kwargs.pop("commit", True)
@@ -108,12 +114,15 @@ class UserEditForm(ModelForm):
 class ResendConfirmationForm(forms.Form):
     email = forms.EmailField()
 
+    def clean_email(self):
+        return normalize_email(self.cleaned_data['email'])
+
 
 class RequestPasswordResetForm(forms.Form):
     email = forms.EmailField()
 
     def clean_email(self):
-        email = self.cleaned_data['email']
+        email = normalize_email(self.cleaned_data['email'])
         if not User.objects.filter(username=email).exists():
             # Many sites say "if the email is registered, we've sent you an email with a password reset link" instead.
             # The idea is not to leak information about which emails are registered. But in our setup we're already
@@ -122,6 +131,11 @@ class RequestPasswordResetForm(forms.Form):
             raise ValidationError("This email is not registered.")
 
         return email
+
+
+class AuthenticationForm(BaseAuthenticationForm):
+    def clean_username(self):
+        return normalize_email(self.cleaned_data['username'])
 
 
 class SetPasswordForm(BaseSetPasswordForm):

--- a/users/management/commands/create_set_password_link.py
+++ b/users/management/commands/create_set_password_link.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from bugsink.app_settings import get_settings
 from users.models import EmailVerification
+from users.utils import normalize_email
 
 
 User = get_user_model()
@@ -17,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            user = User.objects.get(username=options["email"])
+            user = User.objects.get(username=normalize_email(options["email"]))
         except User.DoesNotExist as e:
             raise CommandError("No user with this email address exists") from e
 

--- a/users/management/commands/lowercase_user_emails.py
+++ b/users/management/commands/lowercase_user_emails.py
@@ -1,0 +1,39 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from bugsink.transaction import immediate_atomic
+
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = (
+        "Lowercases the username/email of all users; run this once before turning on USER_EMAIL_CASE_INSENSITIVE. "
+        "Users that would collide after lowercasing are reported and left alone; resolve those by hand.")
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        with immediate_atomic():
+            by_target = {}
+            for user in User.objects.all():
+                by_target.setdefault(user.username.lower(), []).append(user)
+
+            colliding = [target for target, users in by_target.items() if len(users) > 1]
+            if colliding:
+                raise CommandError(
+                    "These emails exist more than once (ignoring case); merge or delete by hand first:\n" +
+                    "\n".join("  " + target for target in sorted(colliding)))
+
+            users = [u for u in User.objects.all() if u.username != u.username.lower()]
+            for user in users:
+                self.stdout.write("%s -> %s" % (user.username, user.username.lower()))
+                if not options["dry_run"]:
+                    user.username = user.username.lower()
+                    user.email = user.email.lower()
+                    user.save()
+
+            self.stdout.write("%d user(s) %s" % (len(users), "to update" if options["dry_run"] else "updated"))
+

--- a/users/management/commands/send_welcome_email.py
+++ b/users/management/commands/send_welcome_email.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 
 from users.models import EmailVerification
 from users.tasks import send_welcome_email
+from users.utils import normalize_email
 
 User = get_user_model()
 
@@ -17,7 +18,7 @@ class Command(BaseCommand):
             help="The reason the user was added; will be the first line of the email body.")
 
     def handle(self, *args, **options):
-        email = options["email"]
+        email = normalize_email(options["email"])
         user = User.objects.get(email=email)
 
         # copy/paste from views.py (excluding the comments)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from unittest import skipIf
+from unittest import skipIf, skipUnless
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
@@ -165,6 +165,7 @@ class MixedCaseCheckTestCase(TransactionTestCase):
         User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
         self.assertEqual([], check_emails_are_lowercase(None))
 
+    @skipIf(connection.vendor == "mysql", "MySQL matches case-insensitively; nobody is locked out")
     def test_error_when_setting_is_on_and_mixed_case_users_exist(self):
         User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
 
@@ -174,6 +175,13 @@ class MixedCaseCheckTestCase(TransactionTestCase):
         self.assertEqual(1, len(errors))
         self.assertEqual("users.E001", errors[0].id)
         self.assertIn("Mixed@Example.com", errors[0].msg)
+
+    @skipUnless(connection.vendor == "mysql", "only MySQL matches case-insensitively by collation")
+    def test_no_error_on_mysql_despite_mixed_case_users(self):
+        User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
+
+        with override_settings(USER_EMAIL_CASE_INSENSITIVE=True):
+            self.assertEqual([], check_emails_are_lowercase(None))
 
     def test_no_error_once_lowercased(self):
         User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")

--- a/users/tests.py
+++ b/users/tests.py
@@ -2,12 +2,16 @@ from io import StringIO
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
 from django.urls import reverse
 
-from bugsink.app_settings import get_settings
+from bugsink.app_settings import get_settings, override_settings, CB_ANYBODY
 from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
 
+from .checks import check_emails_are_lowercase
 from .models import EmailVerification
+from .utils import normalize_email
 
 
 User = get_user_model()
@@ -87,3 +91,90 @@ class PreferencesPasswordTestCase(TransactionTestCase):
         user.refresh_from_db()
         self.assertTrue(user.check_password("NewSecurePassw0rd!"))
         self.assertEqual(self.client.get(reverse("preferences")).status_code, 200)
+
+
+class NormalizeEmailTestCase(TestCase):
+    def test_off_by_default(self):
+        self.assertEqual("User.Name@Example.COM", normalize_email("User.Name@Example.COM"))
+
+    def test_on(self):
+        with override_settings(USER_EMAIL_CASE_INSENSITIVE=True):
+            self.assertEqual("user.name@example.com", normalize_email("User.Name@Example.COM"))
+            self.assertEqual("already@lower.com", normalize_email("already@lower.com"))
+            self.assertEqual("", normalize_email(""))
+            self.assertIsNone(normalize_email(None))
+
+
+class CaseInsensitiveEmailTestCase(TransactionTestCase):
+    def test_signup_and_login_ignore_case(self):
+        with override_settings(
+                USER_EMAIL_CASE_INSENSITIVE=True, USER_REGISTRATION=CB_ANYBODY,
+                USER_REGISTRATION_VERIFY_EMAIL=False):
+            response = self.client.post(reverse("signup"), {
+                "username": "User.Name@Example.COM",
+                "password1": "S3curePassw0rd!",
+                "password2": "S3curePassw0rd!",
+            })
+            self.assertEqual(response.status_code, 302)
+
+            user = User.objects.get()
+            self.assertEqual("user.name@example.com", user.username)
+            self.assertEqual("user.name@example.com", user.email)
+
+            self.client.logout()
+            response = self.client.post(reverse("login"), {
+                "username": "USER.NAME@example.com",
+                "password": "S3curePassw0rd!",
+            })
+            self.assertEqual(response.status_code, 302)
+
+    def test_request_reset_password_ignores_case(self):
+        User.objects.create_user(username="user@example.com", email="user@example.com")
+
+        with override_settings(USER_EMAIL_CASE_INSENSITIVE=True):
+            response = self.client.post(reverse("request_reset_password"), {"email": "User@Example.com"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, EmailVerification.objects.count())
+
+
+class LowercaseUserEmailsCommandTestCase(TransactionTestCase):
+    def test_lowercases_and_reports(self):
+        User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
+        User.objects.create_user(username="lower@example.com", email="lower@example.com")
+
+        stdout = StringIO()
+        call_command("lowercase_user_emails", stdout=stdout)
+
+        self.assertTrue(User.objects.filter(username="mixed@example.com", email="mixed@example.com").exists())
+        self.assertIn("1 user(s) updated", stdout.getvalue())
+
+    def test_refuses_on_collision(self):
+        User.objects.create_user(username="Dup@Example.com", email="Dup@Example.com")
+        User.objects.create_user(username="dup@example.com", email="dup@example.com")
+
+        with self.assertRaises(CommandError):
+            call_command("lowercase_user_emails", stdout=StringIO())
+
+
+class MixedCaseCheckTestCase(TransactionTestCase):
+    def test_no_error_when_setting_is_off(self):
+        User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
+        self.assertEqual([], check_emails_are_lowercase(None))
+
+    def test_error_when_setting_is_on_and_mixed_case_users_exist(self):
+        User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
+
+        with override_settings(USER_EMAIL_CASE_INSENSITIVE=True):
+            errors = check_emails_are_lowercase(None)
+
+        self.assertEqual(1, len(errors))
+        self.assertEqual("users.E001", errors[0].id)
+        self.assertIn("Mixed@Example.com", errors[0].msg)
+
+    def test_no_error_once_lowercased(self):
+        User.objects.create_user(username="Mixed@Example.com", email="Mixed@Example.com")
+        call_command("lowercase_user_emails", stdout=StringIO())
+
+        with override_settings(USER_EMAIL_CASE_INSENSITIVE=True):
+            self.assertEqual([], check_emails_are_lowercase(None))

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,8 +1,10 @@
 from io import StringIO
+from unittest import skipIf
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db import connection
 from django.test import TestCase
 from django.urls import reverse
 
@@ -149,6 +151,7 @@ class LowercaseUserEmailsCommandTestCase(TransactionTestCase):
         self.assertTrue(User.objects.filter(username="mixed@example.com", email="mixed@example.com").exists())
         self.assertIn("1 user(s) updated", stdout.getvalue())
 
+    @skipIf(connection.vendor == "mysql", "MySQL's collation is case-insensitive, so such users cannot coexist")
     def test_refuses_on_collision(self):
         User.objects.create_user(username="Dup@Example.com", email="Dup@Example.com")
         User.objects.create_user(username="dup@example.com", email="dup@example.com")

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,9 @@
+from bugsink.app_settings import get_settings
+
+
+def normalize_email(email):
+    """Lowercase `email` when the instance is configured to treat emails case-insensitively."""
+    if email and get_settings().USER_EMAIL_CASE_INSENSITIVE:
+        return email.lower()
+    return email
+


### PR DESCRIPTION
Since this issue is causing us some trouble right now, I've put together a suggestion here on how we might handle it. It's just a suggestion—I'm hoping it might help a little.

This should Including migration of existing instances and the option to control this behavior over environment.

I just noticed that MySQL deaults to case-insensitive so independent of what Bugsink does, a default MySQL can not have two same emails that just differ in case.
https://dev.mysql.com/doc/refman/8.4/en/case-sensitivity.html

Closes #106 