### PR TITLE
Use log messages as display titles

### DIFF
--- a/events/markdown_stacktrace.py
+++ b/events/markdown_stacktrace.py
@@ -50,6 +50,9 @@ def _frames_for_exception(exc):
 def _header_lines(event, exc):
     etype = exc.get("type") or "Exception"
     val = exc.get("value") or ""
+    if event.is_log_message():
+        return [f"# {event.title()}"]
+
     # Two-line title; no platform/event_id/timestamp clutter.
     return [f"# {etype}", val]
 

--- a/events/models.py
+++ b/events/models.py
@@ -10,7 +10,7 @@ from projects.models import Project
 from compat.timestamp import parse_timestamp
 from bugsink.transaction import delay_on_commit
 
-from issues.utils import get_title_for_exception_type_and_value
+from issues.utils import get_title_for_exception_type_and_value, LOG_MESSAGE_TYPE
 
 from .retention import get_random_irrelevance
 from .storage_registry import get_write_storage, get_storage
@@ -201,6 +201,10 @@ class Event(models.Model):
 
     def title(self):
         return get_title_for_exception_type_and_value(self.calculated_type, self.calculated_value)
+
+    def is_log_message(self):
+        # Ingest derives calculated_type from this event's payload.
+        return self.calculated_type == LOG_MESSAGE_TYPE
 
     @classmethod
     def from_ingested(cls, event_metadata, digested_at, digest_order, project_digest_order, stored_event_count, issue,

--- a/events/test_thread_stacktraces.py
+++ b/events/test_thread_stacktraces.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 
 from bsmain.models import AuthToken
 from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
+from issues.utils import get_denormalized_fields_for_data, get_type_and_value_for_data, maybe_empty
 from projects.models import Project, ProjectMembership
 
 from .factories import create_event
@@ -74,17 +75,35 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
         for filename, message, probe_filename in THREAD_STACKTRACE_SAMPLES:
             with self.subTest(filename=filename):
                 data = load_generated_sample(filename)
-                event = create_event(project=self.project, event_data=data, platform=data["platform"])
-
                 entries = get_stacktrace_entries(data)
                 self.assertEqual(1, len(entries))
                 self.assertEqual("Log Message", entries[0]["type"])
                 self.assertEqual(message, entries[0]["value"])
                 self.assertFalse(entries[0]["is_exception_stacktrace"])
 
+                # Copied from digest_event: calculate the fields that normal ingestion stores on Event and Issue.
+                denormalized_fields = get_denormalized_fields_for_data(data)
+                calculated_type, calculated_value = get_type_and_value_for_data(data)
+                denormalized_fields["calculated_type"] = calculated_type
+                denormalized_fields["calculated_value"] = calculated_value
+
+                event = create_event(
+                    project=self.project,
+                    event_data=data,
+                    platform=data["platform"],
+                    level=maybe_empty(data.get("level", "")),
+                    **denormalized_fields,
+                )
+                event.issue.calculated_type = calculated_type
+                event.issue.calculated_value = calculated_value
+                event.issue.save(update_fields=["calculated_type", "calculated_value"])
+
                 response = self.client.get(f"/issues/issue/{event.issue.id}/event/{event.id}/")
-                self.assertContains(response, "Log Message")
                 self.assertContains(response, message)
+                html = response.content.decode()
+                self.assertIn(f">{message}</h1>", html)
+                self.assertIn(f'<span class="font-bold">{data["level"].upper()}</span>', html)
+                self.assertNotRegex(html, r"<h1[^>]*>Log Message</h1>")
                 self.assertContains(response, probe_filename)
                 self.assertNotContains(response, "capture point")
                 self.assertNotContains(response, "raise Log Message")
@@ -94,8 +113,8 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
                 self.assertNotContains(response, "No stacktrace available for this event.")
 
                 markdown = render_stacktrace_md(event)
-                self.assertIn("# Log Message", markdown)
-                self.assertIn(message, markdown)
+                self.assertIn(f"# {message}", markdown)
+                self.assertNotIn("# Log Message", markdown)
                 self.assertIn(probe_filename, markdown)
                 self.assertNotIn("Thread 1", markdown)
                 self.assertNotEqual("_No stacktrace available._", markdown)

--- a/issues/models.py
+++ b/issues/models.py
@@ -24,7 +24,7 @@ from tags.models import IssueTag, TagValue
 from .grouping_mechanisms import GROUPING_CHOICES
 from .utils import (
     parse_lines, serialize_lines, filter_qs_for_fixed_at, exclude_qs_for_fixed_at,
-    get_title_for_exception_type_and_value)
+    get_title_for_exception_type_and_value, LOG_MESSAGE_TYPE)
 
 from .tasks import delete_issue_deps
 
@@ -102,6 +102,10 @@ class Issue(models.Model):
 
     def title(self):
         return get_title_for_exception_type_and_value(self.calculated_type, self.calculated_value)
+
+    def is_log_message(self):
+        # Ingest keeps calculated_type in sync with the issue's latest event.
+        return self.calculated_type == LOG_MESSAGE_TYPE
 
     def get_fixed_at(self):
         return parse_lines(self.fixed_at)

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -88,8 +88,12 @@
     </div> {# top, RHS (buttons) #}
 
     <div class="overflow-hidden"><!-- top, LHS (various texts) -->
+        {% if issue.is_log_message %}
+        <h1 class="text-4xl font-bold text-ellipsis whitespace-nowrap overflow-hidden pb-1 {# needed for descenders of 'g' #}">{{ issue.title }}</h1>
+        {% else %}
         <h1 class="text-4xl font-bold text-ellipsis whitespace-nowrap overflow-hidden pb-1 {# needed for descenders of 'g' #}">{{ issue.calculated_type }}</h1>
         <div class="text-xl text-ellipsis whitespace-nowrap overflow-hidden">{{ issue.calculated_value }}</div>
+        {% endif %}
         {% if request_repr %}<div class="italic mt-4">{{ request_repr }}</div>{% endif %}
         <div class="text-ellipsis whitespace-nowrap overflow-hidden"><span class="font-bold">{% if issue.last_frame_module %}{{ issue.last_frame_module}}{% else %}{{ issue.last_frame_filename }}{% endif %}</span>{% if issue.last_frame_function %} in <span class="font-bold">{{ issue.last_frame_function }}</span>{% endif %}</div>
     </div> {# top, LHS (various texts) #}

--- a/issues/templates/issues/base.html
+++ b/issues/templates/issues/base.html
@@ -95,7 +95,7 @@
         <div class="text-xl text-ellipsis whitespace-nowrap overflow-hidden">{{ issue.calculated_value }}</div>
         {% endif %}
         {% if request_repr %}<div class="italic mt-4">{{ request_repr }}</div>{% endif %}
-        <div class="text-ellipsis whitespace-nowrap overflow-hidden"><span class="font-bold">{% if issue.last_frame_module %}{{ issue.last_frame_module}}{% else %}{{ issue.last_frame_filename }}{% endif %}</span>{% if issue.last_frame_function %} in <span class="font-bold">{{ issue.last_frame_function }}</span>{% endif %}</div>
+        <div class="text-ellipsis whitespace-nowrap overflow-hidden"><span class="font-bold">{% if issue.last_frame_module %}{{ issue.last_frame_module}}{% else %}{{ issue.last_frame_filename }}{% endif %}</span>{% if issue.last_frame_function %} in <span class="font-bold">{{ issue.last_frame_function }}</span>{% endif %}{% if issue.is_log_message and event.level %}{% if issue.last_frame_module or issue.last_frame_filename or issue.last_frame_function %} | {% endif %}<span class="font-bold">{{ event.level|upper }}</span>{% endif %}</div>
     </div> {# top, LHS (various texts) #}
 
 </div>

--- a/issues/templates/issues/stacktrace.html
+++ b/issues/templates/issues/stacktrace.html
@@ -30,13 +30,13 @@
 {% for exception in exceptions %}
 
     {% if exception.is_exception_stacktrace or forloop.first %}
-    <div class="{% if forloop.counter0 > 0 %}mt-4{% endif %}">
+    <div class="{% if forloop.counter0 > 0 %}mt-4{% endif %}{% if event.is_log_message %} mb-4{% endif %}">
         <div class="flex items-start flex-col-reverse lg:flex-row xl:flex-col-reverse 2xl:flex-row"> {# buttons above titles, or not? 'flips', because at 'xl:...' some space is eaten by the "Key Issue Info" box #}
             <div class="min-w-0 overflow-hidden">
                 {% if forloop.counter0 == 0 %}
                 <div class="italic text-ellipsis whitespace-nowrap overflow-hidden">{{ event.ingested_at|date:"j M G:i T" }} (Event {{ event.digest_order|intcomma }} of {{ issue.digested_event_count|intcomma }} total{% if q %} — {{ event_qs_count|intcomma }} found by search{% endif %})</div>
                 {% endif %}
-                <h1 class="text-2xl font-bold text-ellipsis whitespace-nowrap overflow-hidden">{{ exception.type }}</h1>
+                <h1 class="text-2xl font-bold text-ellipsis whitespace-nowrap overflow-hidden">{% if event.is_log_message %}{{ event.title }}{% else %}{{ exception.type }}{% endif %}</h1>
             </div>
 
             {% if forloop.counter0 == 0 %}
@@ -73,7 +73,9 @@
             {% endif %}
         </div>
 
+        {% if not event.is_log_message %}
         <div class="text-lg mb-4 text-ellipsis whitespace-nowrap overflow-hidden">{{ exception.value }}</div>
+        {% endif %}
     </div>
     {% endif %}
 

--- a/issues/test_titles.py
+++ b/issues/test_titles.py
@@ -1,0 +1,17 @@
+from django.test import SimpleTestCase
+
+from issues.utils import get_title_for_exception_type_and_value
+
+
+class DisplayTitleTestCase(SimpleTestCase):
+    def test_exception_title_contains_type_and_value(self):
+        self.assertEqual(
+            "ValueError: invalid value",
+            get_title_for_exception_type_and_value("ValueError", "invalid value"),
+        )
+
+    def test_log_message_title_is_the_message(self):
+        self.assertEqual(
+            "Could not reach upstream",
+            get_title_for_exception_type_and_value("Log Message", "Could not reach upstream"),
+        )

--- a/issues/tests.py
+++ b/issues/tests.py
@@ -583,6 +583,17 @@ class ViewTests(TransactionTestCase):
 
         self.assertRegex(response.content.decode(), r"<h1[^>]*>Could not reach upstream</h1>")
 
+    def test_log_level_is_shown_below_the_log_message_heading(self):
+        self.issue.calculated_type = "Log Message"
+        self.issue.calculated_value = "Could not reach upstream"
+        self.issue.save(update_fields=["calculated_type", "calculated_value"])
+        self.event.level = "warning"
+        self.event.save(update_fields=["level"])
+
+        response = self.client.get(f"/issues/issue/{self.issue.id}/event/{self.event.id}/")
+
+        self.assertContains(response, '<span class="font-bold">WARNING</span>')
+
     def test_exception_type_and_value_remain_in_the_issue_page_header(self):
         self.issue.calculated_type = "ValueError"
         self.issue.calculated_value = "invalid value"

--- a/issues/tests.py
+++ b/issues/tests.py
@@ -574,6 +574,26 @@ class ViewTests(TransactionTestCase):
         self.assertEqual(0, self.project.issue_count)
         self.assertEqual(0, other_project.issue_count)
 
+    def test_log_message_is_the_issue_page_heading(self):
+        self.issue.calculated_type = "Log Message"
+        self.issue.calculated_value = "Could not reach upstream"
+        self.issue.save(update_fields=["calculated_type", "calculated_value"])
+
+        response = self.client.get(f"/issues/issue/{self.issue.id}/event/{self.event.id}/")
+
+        self.assertRegex(response.content.decode(), r"<h1[^>]*>Could not reach upstream</h1>")
+
+    def test_exception_type_and_value_remain_in_the_issue_page_header(self):
+        self.issue.calculated_type = "ValueError"
+        self.issue.calculated_value = "invalid value"
+        self.issue.save(update_fields=["calculated_type", "calculated_value"])
+
+        response = self.client.get(f"/issues/issue/{self.issue.id}/event/{self.event.id}/")
+
+        html = response.content.decode()
+        self.assertRegex(html, r"<h1[^>]*>ValueError</h1>")
+        self.assertRegex(html, r'<div class="text-xl[^"]*">invalid value</div>')
+
     def test_issue_details(self):
         response = self.client.get(f"/issues/issue/{self.issue.id}/event/{self.event.id}/details/")
         self.assertContains(response, self.issue.title())

--- a/issues/utils.py
+++ b/issues/utils.py
@@ -7,6 +7,9 @@ from sentry.at_glitchtip_af9a700a8706.utils.safe import get_path, trim
 from sentry.at_glitchtip_af9a700a8706.utils.strings import strip
 
 
+LOG_MESSAGE_TYPE = "Log Message"
+
+
 def maybe_empty(s):
     return "" if not s else s
 
@@ -54,9 +57,7 @@ def get_type_and_value_for_data(data):
 
 
 def get_exception_type_and_value_for_logmessage(data):
-    """In Sentry's data-model, log messages are retrofitted into the event model; personally I'm not a fan of using an
-    Error Tracking tool for logging, but we at least make sure to show meaningful titles for log messages. The Bugsink
-    choice is: just use "Log Message" as the type, which at least clarifies what you're looking at"""
+    """Use "Log Message" to classify non-exception events internally; their message is the useful display title."""
 
     message = strip(
         get_path(data, "logentry", "message")
@@ -72,9 +73,9 @@ def get_exception_type_and_value_for_logmessage(data):
         message = data.get("message")
 
     if message:
-        return "Log Message", message.splitlines()[0][:1024]
+        return LOG_MESSAGE_TYPE, message.splitlines()[0][:1024]
 
-    return "Log Message", "<no log message>"
+    return LOG_MESSAGE_TYPE, "<no log message>"
 
 
 def get_main_exception(data):
@@ -161,14 +162,14 @@ def get_key_with_mechanism_for_data(data, grouping_mechanism):
 
 
 def get_title_for_exception_type_and_value(type_, value):
-    # This is a simple function that formats the type and value of an exception in a way that's suitable for use as a
-    # title. It's used in grouping, but also to actually display the title of an issue in the UI.
-
     if not value:
         return type_
 
     if not isinstance(value, str):
         value = str(value)
+
+    if type_ == LOG_MESSAGE_TYPE:
+        return value.splitlines()[0]
 
     return "{}: {}".format(type_, value.splitlines()[0])
 


### PR DESCRIPTION
Bugsink has historically classified non-exception events as Log Message and displayed that generic type prominently. Experience with log-heavy projects changed that judgment: the classification obscures the useful message.

This PR keeps Log Message as the internal classification, but uses the message itself as the display title:

- issue and event lists lead with the message;
- issue and stacktrace headings lead with the message;
- Markdown stacktraces use the message as their heading;
- log levels appear in the issue-page metadata line;
- exception titles and exception-chain presentation remain unchanged.

Grouping continues to use the frozen versioned grouping helpers, so this is strictly a presentation change and does not regroup existing events.

Fix #364.