### PR TITLE
Various smaller issues

### DIFF
--- a/alerts/tasks.py
+++ b/alerts/tasks.py
@@ -15,9 +15,14 @@ def _get_users_for_email_alert(issue):
     # an async task)
 
     pms = list(
-        ProjectMembership.objects.filter(project=issue.project).exclude(send_email_alerts=False).select_related("user"))
+        ProjectMembership.objects.filter(
+            project=issue.project, accepted=True, user__is_active=True,
+        ).exclude(send_email_alerts=False).select_related("user"))
     user_ids = [pm.user_id for pm in pms]
-    tms = {tm.user_id: tm for tm in TeamMembership.objects.filter(team=issue.project.team, user_id__in=user_ids)}
+    tms = {
+        tm.user_id: tm
+        for tm in TeamMembership.objects.filter(team=issue.project.team, user_id__in=user_ids, accepted=True)
+    }
     for pm in pms:
         if pm.send_email_alerts is True:
             yield pm.user

--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -40,6 +40,7 @@ class TestAlertSending(DjangoTestCase):
             project=project,
             user=user,
             send_email_alerts=True,
+            accepted=True,
         )
 
         issue, _ = get_or_create_issue(project=project)
@@ -57,6 +58,7 @@ class TestAlertSending(DjangoTestCase):
             project=project,
             user=user,
             send_email_alerts=True,
+            accepted=True,
         )
 
         issue, _ = get_or_create_issue(project=project)
@@ -74,6 +76,7 @@ class TestAlertSending(DjangoTestCase):
             project=project,
             user=user,
             send_email_alerts=True,
+            accepted=True,
         )
 
         issue, _ = get_or_create_issue(project=project)
@@ -110,7 +113,7 @@ class TestAlertSending(DjangoTestCase):
         self.assertEqual(list(_get_users_for_email_alert(issue)), [])
 
         # ProjectMembership w/ send=False, should not be included
-        pm = ProjectMembership.objects.create(project=project, user=user, send_email_alerts=False)
+        pm = ProjectMembership.objects.create(project=project, user=user, send_email_alerts=False, accepted=True)
         self.assertEqual(list(_get_users_for_email_alert(issue)), [])
 
         # ProjectMembership w/ send=True, should be included
@@ -130,7 +133,7 @@ class TestAlertSending(DjangoTestCase):
 
         # Insert TeamMembership - this provides an intermediate layer of configuration between User and
         # ProjectMembership; we start with send=True at the tm level and expect the user to be included
-        tm = TeamMembership.objects.create(team=team, user=user, send_email_alerts=True)
+        tm = TeamMembership.objects.create(team=team, user=user, send_email_alerts=True, accepted=True)
         self.assertEqual(list(_get_users_for_email_alert(issue)), [user])
 
         # Set send=False at the tm level, user should not be included

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -130,7 +130,7 @@ BUGSINK = {
     # you can customize this as e.g. "My Bugsink" or "Bugsink for My Company"
     "SITE_TITLE": os.getenv("SITE_TITLE", "Bugsink"),
 
-    "USE_ADMIN": os.getenv("USE_ADMIN", False),
+    "USE_ADMIN": os.getenv("USE_ADMIN", "False").lower() in ("true", "1", "yes"),
 
     # Settings for Users, Teams and Projects
     "SINGLE_USER": os.getenv("SINGLE_USER", "False").lower() in ("true", "1", "yes"),

--- a/bugsink/views.py
+++ b/bugsink/views.py
@@ -58,6 +58,12 @@ debug.technical_404_response = cors_for_api_view(debug.technical_404_response)
 debug.technical_500_response = cors_for_api_view(debug.technical_500_response)
 
 
+def _exception_for_error_page(exception):
+    if get_bugsink_settings().MINIMIZE_INFORMATION_EXPOSURE:
+        return Exception("")
+    return exception
+
+
 @phone_home
 def home(request):
     accepted_projects = request.user.project_set.filter(projectmembership__accepted=True).distinct()
@@ -228,8 +234,7 @@ def silence_email_system_warning(request):
 @cors_for_api_view
 def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
     # verbatim copy of Django's default bad_request view, but with "exception" in the context
-    # doing this for any-old-Django-site is probably a bad idea, but here the security/convenience tradeoff is fine,
-    # especially because we only show str(exception) in the template.
+    # (unless MINIMIZE_INFORMATION_EXPOSURE is enabled).
     if request.path.startswith("/api/"):
         template_name = "4xx_5xx_api.txt"
 
@@ -243,15 +248,14 @@ def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
             ERROR_PAGE_TEMPLATE % {"title": "Bad Request (400)", "details": ""},
         )
 
-    return HttpResponseBadRequest(template.render({"exception": exception}))
+    return HttpResponseBadRequest(template.render({"exception": _exception_for_error_page(exception)}))
 
 
 @requires_csrf_token
 @cors_for_api_view
 def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
     # verbatim copy of Django's default server_error view, but with "exception" in the context
-    # doing this for any-old-Django-site is probably a bad idea, but here the security/convenience tradeoff is fine,
-    # especially because we only show str(exception) in the template.
+    # (unless MINIMIZE_INFORMATION_EXPOSURE is enabled).
     _, exception, _ = sys.exc_info()
 
     if request.path.startswith("/api/"):
@@ -267,7 +271,7 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
             ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
         )
 
-    return HttpResponseServerError(template.render({"exception": exception}))
+    return HttpResponseServerError(template.render({"exception": _exception_for_error_page(exception)}))
 
 
 @requires_csrf_token
@@ -280,7 +284,7 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
     # * try to give a correct content-type on-response
     if request.path.startswith("/api/"):
         template_name = "4xx_5xx_api.txt"
-    return django_permission_denied(request, exception, template_name)
+    return django_permission_denied(request, _exception_for_error_page(exception), template_name)
 
 
 @requires_csrf_token
@@ -288,4 +292,4 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
 def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
     if request.path.startswith("/api/"):
         template_name = "4xx_5xx_api.txt"
-    return django_page_not_found(request, exception, template_name)
+    return django_page_not_found(request, _exception_for_error_page(exception), template_name)

--- a/projects/models.py
+++ b/projects/models.py
@@ -188,7 +188,7 @@ class Project(models.Model):
         if user is not None:
             # take the user's team membership into account
             try:
-                TeamMembership.objects.get(team=self.team, user=user)
+                TeamMembership.objects.get(team=self.team, user=user, accepted=True)
                 return True
             except TeamMembership.DoesNotExist:
                 pass

--- a/projects/views.py
+++ b/projects/views.py
@@ -46,7 +46,9 @@ def project_list(request, ownership_filter=None):
 
     my_teams_projects = \
         Project.objects \
-        .filter(team_id__in=TeamMembership.objects.filter(user=request.user).values('team_id'), is_deleted=False) \
+        .filter(
+            team_id__in=TeamMembership.objects.filter(user=request.user, accepted=True).values('team_id'),
+            is_deleted=False) \
         .exclude(projectmembership__in=my_memberships) \
         .order_by('name').distinct()
 
@@ -55,13 +57,13 @@ def project_list(request, ownership_filter=None):
         other_projects = Project.objects \
             .filter(is_deleted=False) \
             .exclude(id__in=ProjectMembership.objects.filter(user=request.user).values('project_id')) \
-            .exclude(team_id__in=TeamMembership.objects.filter(user=request.user).values('team_id')) \
+            .exclude(team_id__in=TeamMembership.objects.filter(user=request.user, accepted=True).values('team_id')) \
             .order_by('name').distinct()
     else:
         other_projects = Project.objects \
             .filter(is_deleted=False) \
             .exclude(id__in=ProjectMembership.objects.filter(user=request.user).values('project_id')) \
-            .exclude(team_id__in=TeamMembership.objects.filter(user=request.user).values('team_id')) \
+            .exclude(team_id__in=TeamMembership.objects.filter(user=request.user, accepted=True).values('team_id')) \
             .exclude(visibility=ProjectVisibility.TEAM_MEMBERS) \
             .order_by('name').distinct()
 


### PR DESCRIPTION
- Require accepted team membership before users can list or join team-only projects (
- Send issue alerts only to active users with accepted project memberships, and ignore preferences from pending team memberships.
- Parse Docker’s `USE_ADMIN` environment variable as a boolean.
- Hide exception details from production error responses when `MINIMIZE_INFORMATION_EXPOSURE` is enabled.

(regarding the first 2 bullets: Pending invitees already controlled whether to accept, so this was not a practical security issue but more of an inconsistency being ironed out here)