### PR TITLE
Render top-level event stacktraces

### DIFF
--- a/events/tests.py
+++ b/events/tests.py
@@ -23,11 +23,39 @@ from .retention import (
 from .sparklines import (
     get_issue_event_sparkline, get_issue_list_event_sparklines, get_sparkline_range, get_y_labels)
 from .usage import EVENT_COUNTS_PER_HOUR_MAX_AGE, hour_bucket, record_event_counts
-from .utils import annotate_with_meta, annotate_var_with_meta
+from .utils import annotate_with_meta, annotate_var_with_meta, get_stacktrace_entries
 from tags.models import EventTag, store_tags
 from tags.search import search_events
 
 User = get_user_model()
+
+
+class StacktraceEntriesTestCase(RegularTestCase):
+    def test_top_level_stacktrace_is_used_as_last_fallback(self):
+        stacktrace = {"frames": [{"filename": "scheduler.php", "lineno": 176}]}
+
+        entries = get_stacktrace_entries({
+            "logentry": {"formatted": "Scheduler task failed"},
+            "stacktrace": stacktrace,
+        })
+
+        self.assertEqual([{
+            "type": "Log Message",
+            "value": "Scheduler task failed",
+            "stacktrace": stacktrace,
+            "is_exception_stacktrace": False,
+        }], entries)
+
+    def test_thread_stacktrace_takes_precedence_over_top_level_stacktrace(self):
+        thread_stacktrace = {"frames": [{"filename": "thread.php"}]}
+
+        entries = get_stacktrace_entries({
+            "logentry": {"formatted": "Scheduler task failed"},
+            "threads": {"values": [{"stacktrace": thread_stacktrace}]},
+            "stacktrace": {"frames": [{"filename": "deprecated.php"}]},
+        })
+
+        self.assertEqual(thread_stacktrace, entries[0]["stacktrace"])
 
 
 class ViewTests(TransactionTestCase):

--- a/events/utils.py
+++ b/events/utils.py
@@ -52,10 +52,15 @@ def get_thread_stacktrace_entries(event_data):
             first_with_frames = i
 
         entries.append({
+            "stacktrace": stacktrace,
+
+            # Bugsink's internal stacktrace-entry interface requires type/value; and threads have neither.
             "type": type_,
             "value": value,
-            "stacktrace": stacktrace,
+
+            # thread stacktraces do not have "raise" frame labels / chained exceptions:
             "is_exception_stacktrace": False,
+
             "thread_title": _thread_title(thread),
             "thread_description": _thread_description(thread),
         })
@@ -72,7 +77,25 @@ def get_stacktrace_entries(event_data):
     if exceptions:
         return [dict(exception, is_exception_stacktrace=True) for exception in exceptions]
 
-    return get_thread_stacktrace_entries(event_data)
+    threads = get_thread_stacktrace_entries(event_data)
+    if threads:
+        return threads
+
+    stacktrace = event_data.get("stacktrace") or {}
+    if not stacktrace.get("frames"):
+        return []
+
+    type_, value = get_type_and_value_for_data(event_data)
+    return [{
+        "stacktrace": stacktrace,
+
+        # Bugsink's internal stacktrace-entry interface requires type/value; and an event-level stacktrace has neither.
+        "type": type_,
+        "value": value,
+
+        # Event-level stacktraces do not have "raise" frame labels / chained exceptions:
+        "is_exception_stacktrace": False,
+    }]
 
 
 class IncompleteList(list):


### PR DESCRIPTION
As per the API schema: there is something called an "event stacktrace", which is to say `stacktrace` at the event top level rather than `exception.values[*].stacktrace`. That interface is deprecated, but legal.

Events using it reached the stacktrace page but showed no frames because stacktrace discovery only considered the two preferred interfaces.

Use the top-level interface as the final fallback after exceptions and threads.

Fix #482