### PR TITLE
Simplify get_stacktrace_entries interface

### DIFF
--- a/events/markdown_stacktrace.py
+++ b/events/markdown_stacktrace.py
@@ -48,10 +48,11 @@ def _frames_for_exception(exc):
 
 
 def _header_lines(event, exc):
+    if not exc["is_exception_stacktrace"]:
+        return [f"# {event.title()}"]
+
     etype = exc.get("type") or "Exception"
     val = exc.get("value") or ""
-    if event.is_log_message():
-        return [f"# {event.title()}"]
 
     # Two-line title; no platform/event_id/timestamp clutter.
     return [f"# {etype}", val]

--- a/events/test_thread_stacktraces.py
+++ b/events/test_thread_stacktraces.py
@@ -61,6 +61,25 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
         token = AuthToken.objects.create()
         self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
 
+    def create_event_from_sample(self, data):
+        # create_event bypasses ingestion; fake the denormalized fields that digest_event would have stored.
+        denormalized_fields = get_denormalized_fields_for_data(data)
+        calculated_type, calculated_value = get_type_and_value_for_data(data)
+        denormalized_fields["calculated_type"] = calculated_type
+        denormalized_fields["calculated_value"] = calculated_value
+
+        event = create_event(
+            project=self.project,
+            event_data=data,
+            platform=data["platform"],
+            level=maybe_empty(data.get("level", "")),
+            **denormalized_fields,
+        )
+        event.issue.calculated_type = calculated_type
+        event.issue.calculated_value = calculated_value
+        event.issue.save(update_fields=["calculated_type", "calculated_value"])
+        return event
+
     def test_capture_exception_uses_its_exception_stacktrace(self):
         data = load_generated_sample("sentry-python-capture-exception-add-full-stack.json")
 
@@ -75,28 +94,7 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
         for filename, message, probe_filename in THREAD_STACKTRACE_SAMPLES:
             with self.subTest(filename=filename):
                 data = load_generated_sample(filename)
-                entries = get_stacktrace_entries(data)
-                self.assertEqual(1, len(entries))
-                self.assertEqual("Log Message", entries[0]["type"])
-                self.assertEqual(message, entries[0]["value"])
-                self.assertFalse(entries[0]["is_exception_stacktrace"])
-
-                # Copied from digest_event: calculate the fields that normal ingestion stores on Event and Issue.
-                denormalized_fields = get_denormalized_fields_for_data(data)
-                calculated_type, calculated_value = get_type_and_value_for_data(data)
-                denormalized_fields["calculated_type"] = calculated_type
-                denormalized_fields["calculated_value"] = calculated_value
-
-                event = create_event(
-                    project=self.project,
-                    event_data=data,
-                    platform=data["platform"],
-                    level=maybe_empty(data.get("level", "")),
-                    **denormalized_fields,
-                )
-                event.issue.calculated_type = calculated_type
-                event.issue.calculated_value = calculated_value
-                event.issue.save(update_fields=["calculated_type", "calculated_value"])
+                event = self.create_event_from_sample(data)
 
                 response = self.client.get(f"/issues/issue/{event.issue.id}/event/{event.id}/")
                 self.assertContains(response, message)
@@ -132,7 +130,7 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
 
     def test_multiple_threads_render_in_markdown(self):
         data = load_generated_sample(JAVA_MULTIPLE_THREADS_SAMPLE)
-        event = create_event(project=self.project, event_data=data, platform=data["platform"])
+        event = self.create_event_from_sample(data)
 
         markdown = render_stacktrace_md(event)
 
@@ -149,7 +147,7 @@ class ThreadStacktraceSampleTests(TransactionTestCase):
 
     def test_exception_and_threads_render_in_markdown(self):
         data = load_generated_sample(JAVA_EXCEPTION_THREADS_SAMPLE)
-        event = create_event(project=self.project, event_data=data, platform=data["platform"])
+        event = self.create_event_from_sample(data)
 
         markdown = render_stacktrace_md(event)
 

--- a/events/tests.py
+++ b/events/tests.py
@@ -31,6 +31,26 @@ User = get_user_model()
 
 
 class StacktraceEntriesTestCase(RegularTestCase):
+    def test_thread_stacktrace_entry_contains_thread_fields(self):
+        stacktrace = {"frames": [{"filename": "worker.py"}]}
+
+        entries = get_stacktrace_entries({
+            "threads": {"values": [{
+                "id": 7,
+                "name": "worker",
+                "crashed": False,
+                "state": "waiting",
+                "stacktrace": stacktrace,
+            }]},
+        })
+
+        self.assertEqual([{
+            "stacktrace": stacktrace,
+            "is_exception_stacktrace": False,
+            "thread_title": "Thread #7: worker",
+            "thread_description": "errored: no, state: Waiting",
+        }], entries)
+
     def test_top_level_stacktrace_is_used_as_last_fallback(self):
         stacktrace = {"frames": [{"filename": "scheduler.php", "lineno": 176}]}
 
@@ -40,8 +60,6 @@ class StacktraceEntriesTestCase(RegularTestCase):
         })
 
         self.assertEqual([{
-            "type": "Log Message",
-            "value": "Scheduler task failed",
             "stacktrace": stacktrace,
             "is_exception_stacktrace": False,
         }], entries)

--- a/events/utils.py
+++ b/events/utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 import json
 import ecma426
-from issues.utils import get_type_and_value_for_data, get_values
+from issues.utils import get_values
 
 from bugsink.transaction import delay_on_commit
 from bugsink.utils import assert_
@@ -43,7 +43,6 @@ def get_thread_stacktrace_entries(event_data):
     if not threads:
         return []  # The threads interface is optional.
 
-    type_, value = get_type_and_value_for_data(event_data)
     entries = []
     first_with_frames = None
     for i, thread in enumerate(threads):
@@ -53,10 +52,6 @@ def get_thread_stacktrace_entries(event_data):
 
         entries.append({
             "stacktrace": stacktrace,
-
-            # Bugsink's internal stacktrace-entry interface requires type/value; and threads have neither.
-            "type": type_,
-            "value": value,
 
             # thread stacktraces do not have "raise" frame labels / chained exceptions:
             "is_exception_stacktrace": False,
@@ -85,13 +80,8 @@ def get_stacktrace_entries(event_data):
     if not stacktrace.get("frames"):
         return []
 
-    type_, value = get_type_and_value_for_data(event_data)
     return [{
         "stacktrace": stacktrace,
-
-        # Bugsink's internal stacktrace-entry interface requires type/value; and an event-level stacktrace has neither.
-        "type": type_,
-        "value": value,
 
         # Event-level stacktraces do not have "raise" frame labels / chained exceptions:
         "is_exception_stacktrace": False,

--- a/issues/templates/issues/stacktrace.html
+++ b/issues/templates/issues/stacktrace.html
@@ -36,7 +36,7 @@
                 {% if forloop.counter0 == 0 %}
                 <div class="italic text-ellipsis whitespace-nowrap overflow-hidden">{{ event.ingested_at|date:"j M G:i T" }} (Event {{ event.digest_order|intcomma }} of {{ issue.digested_event_count|intcomma }} total{% if q %} — {{ event_qs_count|intcomma }} found by search{% endif %})</div>
                 {% endif %}
-                <h1 class="text-2xl font-bold text-ellipsis whitespace-nowrap overflow-hidden">{% if event.is_log_message %}{{ event.title }}{% else %}{{ exception.type }}{% endif %}</h1>
+                <h1 class="text-2xl font-bold text-ellipsis whitespace-nowrap overflow-hidden">{% if exception.is_exception_stacktrace %}{{ exception.type }}{% else %}{{ event.title }}{% endif %}</h1>
             </div>
 
             {% if forloop.counter0 == 0 %}
@@ -73,7 +73,7 @@
             {% endif %}
         </div>
 
-        {% if not event.is_log_message %}
+        {% if exception.is_exception_stacktrace %}
         <div class="text-lg mb-4 text-ellipsis whitespace-nowrap overflow-hidden">{{ exception.value }}</div>
         {% endif %}
     </div>

--- a/issues/test_stacktrace_view.py
+++ b/issues/test_stacktrace_view.py
@@ -247,7 +247,6 @@ class StacktraceViewTests(TransactionTestCase):
         text = visible_text(self.render_stacktrace(event_data))
         message = "capture_message with all Java threads from ProbeMultipleThreads.java"
 
-        self.assertIn("Log Message", text)
         self.assertEqual(1, text.count(message))
         self.assertLess(text.index(message), text.index("Thread #1: main"))
         self.assertIn("Thread #1: main", text)

--- a/issues/test_stacktrace_view.py
+++ b/issues/test_stacktrace_view.py
@@ -9,6 +9,7 @@ from django.utils.html import strip_tags
 
 from bugsink.test_utils import TransactionTestCase25251 as TransactionTestCase
 from events.factories import create_event
+from issues.utils import get_type_and_value_for_data
 from projects.models import Project, ProjectMembership
 
 
@@ -33,10 +34,14 @@ class StacktraceViewTests(TransactionTestCase):
         self.client.force_login(self.user)
 
     def render_stacktrace(self, event_data):
+        # create_event bypasses ingestion; fake the denormalized fields that digest_event would have stored.
+        calculated_type, calculated_value = get_type_and_value_for_data(event_data)
         event = create_event(
             project=self.project,
             event_data=event_data,
             platform=event_data["platform"],
+            calculated_type=calculated_type,
+            calculated_value=calculated_value,
         )
         return self.client.get(f"/issues/issue/{event.issue.id}/event/{event.id}/")
 


### PR DESCRIPTION
fixes the (recently established) interface of `get_stacktrace_entries`; see commit message for details.