### PR TITLE
Display formatted log messages in issue titles

### DIFF
--- a/issues/test_grouping_v2.py
+++ b/issues/test_grouping_v2.py
@@ -52,6 +52,12 @@ class GroupingV2TestCase(DjangoTestCase):
         self.assertEqual("KeyError: exception message", first_key)
         self.assertEqual(first_key, second_key)
 
+    def test_logentry_message_takes_precedence(self):
+        self.assertEqual("Log Message: foo %s", get_grouping_key_for_data({"logentry": {
+            "message": "foo %s",
+            "formatted": "foo bar",
+        }}))
+
     def test_normalized_exception_values_have_stable_grouping_key(self):
         cases = [
             (

--- a/issues/test_titles.py
+++ b/issues/test_titles.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from issues.utils import get_title_for_exception_type_and_value
+from issues.utils import get_title_for_exception_type_and_value, get_type_and_value_for_data
 
 
 class DisplayTitleTestCase(SimpleTestCase):
@@ -14,4 +14,19 @@ class DisplayTitleTestCase(SimpleTestCase):
         self.assertEqual(
             "Could not reach upstream",
             get_title_for_exception_type_and_value("Log Message", "Could not reach upstream"),
+        )
+
+    def test_formatted_log_message_is_the_display_value(self):
+        self.assertEqual(
+            ("Log Message", "foo bar"),
+            get_type_and_value_for_data({"logentry": {
+                "message": "foo %s",
+                "formatted": "foo bar",
+            }}),
+        )
+
+    def test_unformatted_log_message_is_the_display_fallback(self):
+        self.assertEqual(
+            ("Log Message", "foo %s"),
+            get_type_and_value_for_data({"logentry": {"message": "foo %s"}}),
         )

--- a/issues/utils.py
+++ b/issues/utils.py
@@ -60,12 +60,12 @@ def get_exception_type_and_value_for_logmessage(data):
     """Use "Log Message" to classify non-exception events internally; their message is the useful display title."""
 
     message = strip(
-        get_path(data, "logentry", "message")
-        or get_path(data, "logentry", "formatted")
+        get_path(data, "logentry", "formatted")
+        or get_path(data, "logentry", "message")
 
         # top-level "message" (deprecated, but still used by some SDKs, with a dict as with "logentry")
-        or get_path(data, "message", "message")
         or get_path(data, "message", "formatted")
+        or get_path(data, "message", "message")
     )
 
     if not message and isinstance(data.get("message"), str):


### PR DESCRIPTION
as opposed to the "message" (which may have placeholders)

quoting myself over at the issue:

 > we already have a precedent for "group on some generalized thing, display
 > somethng pretty (and update for each new event)". We should just update the
 > display for logging accordingly. No datamigration is needed, precisely
 > because of this "always update" behavior.

See #111