### PR TITLE
Stop SDKs sending unsupported performance data

### DIFF
--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -538,8 +538,36 @@ class IngestViewTestCase(TransactionTestCase):
             )
             self.assertEqual(
                 200, response.status_code, response.content if response.status_code != 302 else response.url)
+            self.assertEqual(
+                "86400:transaction;span:organization",
+                response["X-Sentry-Rate-Limits"],
+            )
+            self.assertEqual("X-Sentry-Rate-Limits", response["Access-Control-Expose-Headers"])
 
             self.assertEqual(0, Event.objects.count())
+
+    @override_settings(MAX_EVENTS_PER_5_MINUTES=1)
+    def test_envelope_endpoint_rate_limit_headers_when_quota_exceeded(self):
+        project = Project.objects.create(name="test")
+        installation = Installation.objects.get()
+        installation.quota_exceeded_until = timezone.now() + relativedelta(minutes=5)
+        installation.quota_exceeded_reason = json.dumps(["minute", 5, 1])
+        installation.save(update_fields=["quota_exceeded_until", "quota_exceeded_reason"])
+
+        sentry_auth_header = get_header_value(f"http://{ project.sentry_key }@hostisignored/{ project.id }")
+        response = self.client.post(
+            f"/api/{ project.id }/envelope/",
+            content_type="application/json",
+            headers={"X-Sentry-Auth": sentry_auth_header},
+            data=b'{}\n{"type": "transaction"}\n{}',
+        )
+
+        self.assertEqual(429, response.status_code)
+        self.assertEqual(
+            "60::key, 86400:transaction;span:organization",
+            response["X-Sentry-Rate-Limits"],
+        )
+        self.assertEqual("X-Sentry-Rate-Limits", response["Access-Control-Expose-Headers"])
 
     def test_envelope_endpoint_unsupported_type_without_event_id(self):
         # dirty copy/paste from the integration test, let's start with "something", we can always clean it later.

--- a/ingest/views.py
+++ b/ingest/views.py
@@ -217,6 +217,7 @@ class BaseIngestAPIView(View):
             "X-Requested-With, Origin, Accept, Authentication, Authorization, Content-Encoding, sentry-trace, "
             "baggage, X-CSRFToken"
         )
+        response["Access-Control-Expose-Headers"] = "X-Sentry-Rate-Limits"
 
         return response
 
@@ -813,6 +814,19 @@ class IngestEventAPIView(BaseIngestAPIView):
 
 
 class IngestEnvelopeAPIView(BaseIngestAPIView):
+
+    def post(self, request, project_pk=None):
+        response = super().post(request, project_pk)
+
+        # We repurpose the Sentry rate-limits header to indicate lack of support for transaction & span.
+        rate_limits = "86400:transaction;span:organization"
+
+        if response.status_code == HTTP_429_TOO_MANY_REQUESTS:
+            # X-Sentry-Rate-Limits takes precedence over the generic backoff implied by a bare 429.
+            rate_limits = "60::key, " + rate_limits
+
+        response["X-Sentry-Rate-Limits"] = rate_limits
+        return response
 
     def _post(self, request, project_pk=None):
         ingested_at = datetime.now(timezone.utc)


### PR DESCRIPTION
Transaction and standalone span envelopes are accepted and discarded, causing needless ingestion load. Advertise category-specific 24-hour limits on envelope responses so SDKs drop them locally.

Note on the shape "86400:transaction;span:organization" we found: There's an optional "reason" we could postpend after "organization" but we have no Sentry-supported reason and it's optional so we leave it out.

Note on "Access-Control-Expose-Headers": this only gives browser SDKs permission to read X-Sentry-Rate-Limits from a cross-origin response. It does not add that header, so declaring it centrally for all ingest views is harmless while the rate-limit header itself remains envelope-only.

On quota 429s, retain the existing generic 60-second backoff explicitly because X-Sentry-Rate-Limits takes precedence over bare-429 handling.