### PR TITLE
Make request URLs searchable (using tags) 

### DIFF
--- a/tags/search.py
+++ b/tags/search.py
@@ -4,7 +4,6 @@ since we have such a prominent role for tags in the actual implementation of sea
 least it means we have all of this together in a separate file this way.
 """
 
-import re
 from django.db.models import Q, Subquery, Count
 from collections import namedtuple
 
@@ -36,26 +35,95 @@ def _and_join(q_objects):
     return result
 
 
-def parse_query(q):
-    # The simplest possible query-language that could have any value: key:value is recognized as such; the rest is "free
-    # text"; no support for quoting of spaces.
-    tags = {}
+def _split_on_spaces_respecting_quotes(q):
+    terms = []
+    start = None
+    in_quotes = False
+    i = 0
 
+    while i < len(q):
+        if start is None:
+            if q[i].isspace():
+                i += 1
+                continue
+            start = i
+
+        if q[i] == "\\" and i + 1 < len(q) and q[i + 1] in ['"', "\\"]:
+            i += 2
+            continue
+
+        if q[i] == '"':
+            in_quotes = not in_quotes
+        elif q[i].isspace() and not in_quotes:
+            terms.append((start, i, True))
+            start = None
+
+        i += 1
+
+    if start is not None:
+        terms.append((start, len(q), not in_quotes))
+
+    return terms
+
+
+def _parse_tag_token(term):
+    in_quotes = False
+    i = 0
+
+    while i < len(term):
+        if term[i] == "\\" and i + 1 < len(term) and term[i + 1] in ['"', "\\"]:
+            i += 2
+            continue
+
+        if term[i] == '"':
+            in_quotes = not in_quotes
+        elif term[i] == ":" and not in_quotes:
+            if i == 0 or i == len(term) - 1:
+                return None
+            return _unquote(term[:i]), _unquote(term[i + 1:])
+
+        i += 1
+
+    return None
+
+
+def _unquote(value):
+    result = []
+    i = 0
+
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value) and value[i + 1] in ['"', "\\"]:
+            result.append(value[i + 1])
+            i += 2
+        elif value[i] == '"':
+            i += 1
+        else:
+            result.append(value[i])
+            i += 1
+
+    return "".join(result)
+
+
+def parse_query(q):
+    tags = {}
     slices_to_remove = []
 
-    # first, match all key:value pairs with unquoted values
-    for match in re.finditer(r'(\S+):([^\s"]+)', q):
-        slices_to_remove.append(match.span())
-        key, value = match.groups()
-        tags[key] = value
+    # First split the query on spaces outside quoted strings.
+    for start, stop, quotes_closed in _split_on_spaces_respecting_quotes(q):
+        if not quotes_closed:
+            continue
 
-    # then, match all key:"quoted value" pairs
-    for match in re.finditer(r'(\S+):"([^"]+)"', q):
-        slices_to_remove.append(match.span())
-        key, value = match.groups()
-        tags[key] = value
+        # Then split each complete token on its first unquoted colon.
+        tag = _parse_tag_token(q[start:stop])
+        if tag is None:
+            continue
 
-    slices_to_remove.sort(key=lambda tup: tup[0])  # _remove_slices expects the slices to be sorted
+        key, value = tag
+        if not key:
+            continue
+
+        tags[key] = value
+        slices_to_remove.append((start, stop))
 
     plain_text_q = _remove_slices(q, slices_to_remove).strip()
 

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -41,6 +41,9 @@ class DeduceTagsTestCase(RegularTestCase):
                 "ip_address": "123.123.123.123",
             },
             "transaction": "main",
+            "request": {
+                "url": "https://www.example.com/checkout/",
+            },
             "contexts": {
                 "trace": {
                     "trace_id": "1f2d3e4f5a6b5c8df9e0a1b2c3d4e5f",
@@ -62,6 +65,7 @@ class DeduceTagsTestCase(RegularTestCase):
             "environment": "prod",
             "handled": "false",
             "transaction": "main",
+            "url": "https://www.example.com/checkout/",
             "trace": "1f2d3e4f5a6b5c8df9e0a1b2c3d4e5f",
             "trace.span": "9a8b7c6d5e4f3a2c",
             "trace.ctx": "1f2d3e4f5a6b5c8df9e0a1b2c3d4e5f.9a8b7c6d5e4f3a2c",
@@ -77,6 +81,16 @@ class DeduceTagsTestCase(RegularTestCase):
             "user.email": "john@doe.org",
             "user.ip_address": "123.123.123.123",
         })
+
+    def test_url_tag_excludes_query_and_fragment(self):
+        for url, expected in [
+            ("https://www.example.com/checkout/", "https://www.example.com/checkout/"),
+            ("https://www.example.com/checkout/?coupon=SAVE", "https://www.example.com/checkout/"),
+            ("https://www.example.com/checkout/#payment", "https://www.example.com/checkout/"),
+            ("https://www.example.com/checkout/?coupon=SAVE#payment", "https://www.example.com/checkout/"),
+        ]:
+            with self.subTest(url=url):
+                self.assertEqual(deduce_tags({"request": {"url": url}}), {"url": expected})
 
 
 class StoreTagsTestCase(DjangoTestCase):
@@ -362,6 +376,21 @@ class SearchTestCase(DjangoTestCase):
 
     def test_search_issues(self):
         self._test_search(lambda query: search_issues(self.project, Issue.objects.all(), query))
+
+    def test_search_issues_by_url(self):
+        issue, _ = get_or_create_issue(project=self.project, event_data=create_event_data("url"))
+        event = create_event(self.project, issue=issue)
+        digest_tags({
+            "request": {"url": "https://www.example.com/checkout/?coupon=SAVE#payment"},
+        }, event, issue)
+
+        result = search_issues(
+            self.project,
+            Issue.objects.all(),
+            'url:"https://www.example.com/checkout/"',
+        )
+
+        self.assertEqual([issue], list(result))
 
 
 class VacuumEventlessIssueTagsTestCase(TransactionTestCase):

--- a/tags/tests.py
+++ b/tags/tests.py
@@ -243,6 +243,36 @@ class SearchParserTestCase(RegularTestCase):
             ({"key": "quoted value"}, "and further text"),
             parse_query('key:"quoted value" and further text'))
 
+        self.assertEqual(({"key": ""}, ""), parse_query('key:""'))
+
+        self.assertEqual(({}, 'key:"unterminated value'), parse_query('key:"unterminated value'))
+
+    def test_parser_supports_escaped_quotes(self):
+        self.assertEqual(({"key": 'a "quoted" value'}, ""), parse_query(r'key:"a \"quoted\" value"'))
+
+    def test_parser_supports_escaped_backslashes(self):
+        self.assertEqual(({"key": "a \\ value"}, ""), parse_query(r'key:"a \\ value"'))
+
+    def test_parser_ignores_colons_inside_quotes(self):
+        self.assertEqual(({"key": "value"}, '"not:a tag"'), parse_query('"not:a tag" key:value'))
+
+        self.assertEqual(({"key": "value:with:colons"}, ""), parse_query('key:"value:with:colons"'))
+
+    def test_parser_splits_on_leftmost_unquoted_colon(self):
+        self.assertEqual(
+            ({"url": "https://www.example.com/checkout/"}, ""), parse_query("url:https://www.example.com/checkout/"))
+
+        self.assertEqual(
+            ({"url": "https://www.example.com/checkout/"}, ""), parse_query('url:"https://www.example.com/checkout/"'))
+
+        self.assertEqual(({"key": "value:with:colons"}, ""), parse_query("key:value:with:colons"))
+
+    def test_parser_uses_last_duplicate_tag(self):
+        self.assertEqual(({"key": "plain"}, ""), parse_query('key:"quoted value" key:plain'))
+
+        self.assertEqual(({"key": "quoted value"}, ""), parse_query('key:plain key:"quoted value"'))
+
+    def test_parser_preserves_spacing_around_removed_tags(self):
         # This is the kind of test that just documents "what is" rather than "what I believe is right". The weirdness
         # here is mostly the double space "on  both" which is the result of just cutting out the key:value bits. But...
         # I'm not invested in getting this more precise (yet), because this whole case is a bit weird. I'd much rather

--- a/tags/utils.py
+++ b/tags/utils.py
@@ -76,6 +76,10 @@ def _convert_non_strings(value):
     return value
 
 
+def _url_without_query_or_fragment(url):
+    return url.split("#", 1)[0].split("?", 1)[0]
+
+
 def deduce_tags(event_data):
     """
     Deduce tags for `event_data`. Used as an "opportunistic" (generic) way to implement counting and searching. Although
@@ -99,6 +103,10 @@ def deduce_tags(event_data):
         # is supposed to just pick the right (non-tag) location for standard tags.
         if value not in [None, ""]:
             tags[tag_key] = _convert_non_strings(value)
+
+    url = get_path(event_data, "request", "url")
+    if url not in [None, ""]:
+        tags["url"] = _url_without_query_or_fragment(url)
 
     # deduce from main exception
     main_exception = get_main_exception(event_data)
@@ -126,12 +134,6 @@ def deduce_tags(event_data):
         tags["os"] = f"{tags['os.name']} {tags['os.version']}"
 
     tags.update(deduce_user_tags(event_data))
-
-    # TODO url is probably useful, but I imagine that its `mostly_unique` property is not statically known, i.e. some
-    # issues may have single url, others may have a few (useful for tag-breakdown) and yet others may have very many
-    # (useful for search). We'll tie implementation of this to the implementation of dynamic `is_mostly_unique`
-    # determination.
-    # url
 
     # TODO For now this is not supported for the same reason as "level" (see above). But it's probably more useful than
     # level, because it will be more likely be a searchable term that "leads somewhere" (i.e. if you know you have a


### PR DESCRIPTION
Request URLs were only stored in event data, so issue and event
search could not filter by them. Store request.url as a derived tag.

Queries and fragments would create needless tag values and make equivalent
pages differ, so exclude both from the URL tag.

Note on "must we do this server-side?": The event schema permits query strings
and fragments in request.url even though separate fields also exist.  (current
JavaScript SDK keeps a query string in both url and query_string, while the
Python WSGI and Go SDKs construct url without it)

Fix https://github.com/bugsink/bugsink/issues/269