### PR TITLE
Fix bug where SMTP settings wouldnt be applied in docker environment

### DIFF
--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -91,30 +91,32 @@ else:
     database_path = os.path.dirname(DATABASES['default']['NAME'])
 
 
-if os.getenv("EMAIL_BACKEND"):
-    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
-elif os.getenv("EMAIL_HOST"):
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"  # default, here for explicitness
+if os.getenv("EMAIL_HOST"):
+    # Default, may be overridden below
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"  
     EMAIL_HOST = os.getenv("EMAIL_HOST")
     EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
     EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
     EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
-    # When neither EMAIL_USE_xxx is set, we default to EMAIL_USE_TLS=True (this matches port 587). If either is set to
-    # True, we use that.
+    
+    # When neither EMAIL_USE_xxx is set, we default to EMAIL_USE_TLS=True (this matches port 587).
     EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "False").lower() in ("true", "1", "yes")
     EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", str(not EMAIL_USE_SSL)).lower() in ("true", "1", "yes")
 
-    if os.getenv("EMAIL_LOGGING", "false").lower() in ("true", "1", "yes"):
-        LOGGING['loggers']['bugsink.email']['level'] = "INFO"
-
-else:
+if os.getenv("EMAIL_BACKEND"):
+    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+elif not os.getenv("EMAIL_HOST"):
     # print("WARNING: EMAIL_HOST not set; email will not be sent")
     EMAIL_BACKEND = "bugsink.email_backends.QuietConsoleEmailBackend"
+
+if os.getenv("EMAIL_LOGGING", "false").lower() in ("true", "1", "yes"):
+    LOGGING['loggers']['bugsink.email']['level'] = "INFO"
 
 if os.getenv("EMAIL_TIMEOUT"):
     EMAIL_TIMEOUT = int(os.getenv("EMAIL_TIMEOUT"))
 
 SERVER_EMAIL = DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "Bugsink <bugsink@example.org>")
+
 
 # constants for "create by" (user/team/project) settings
 CB_ANYBODY = "CB_ANYBODY"

--- a/bugsink/conf_templates/docker.py.template
+++ b/bugsink/conf_templates/docker.py.template
@@ -91,23 +91,23 @@ else:
     database_path = os.path.dirname(DATABASES['default']['NAME'])
 
 
-if os.getenv("EMAIL_HOST"):
-    # Default, may be overridden below
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"  
-    EMAIL_HOST = os.getenv("EMAIL_HOST")
+if os.getenv("EMAIL_BACKEND"):
+    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+elif os.getenv("EMAIL_HOST"):
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+else:
+    # print("WARNING: EMAIL_HOST not set; email will not be sent")
+    EMAIL_BACKEND = "bugsink.email_backends.QuietConsoleEmailBackend"
+
+if EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend" or os.getenv("EMAIL_HOST"):
+    EMAIL_HOST = os.getenv("EMAIL_HOST") or "localhost"
     EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
     EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
     EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
-    
+
     # When neither EMAIL_USE_xxx is set, we default to EMAIL_USE_TLS=True (this matches port 587).
     EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "False").lower() in ("true", "1", "yes")
     EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", str(not EMAIL_USE_SSL)).lower() in ("true", "1", "yes")
-
-if os.getenv("EMAIL_BACKEND"):
-    EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
-elif not os.getenv("EMAIL_HOST"):
-    # print("WARNING: EMAIL_HOST not set; email will not be sent")
-    EMAIL_BACKEND = "bugsink.email_backends.QuietConsoleEmailBackend"
 
 if os.getenv("EMAIL_LOGGING", "false").lower() in ("true", "1", "yes"):
     LOGGING['loggers']['bugsink.email']['level'] = "INFO"


### PR DESCRIPTION
Fixes #502 

The old code checked for EMAIL_BACKEND and would skip all other configurations when set. That lead to a bug where you could explicitly set it to django's email backend, but no further configuration would be applied from the docker env vars. Everything would fall back to default, i.e. localhost:25 with no user and password set. Now it's defaulting to smtp when host is set, but may be overwritten by user's own EMAIL_BACKEND. I also took logging out of that if/else block, since it should be settable independently.