### PR TITLE
add prometheus exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changes
 
-## 2.5.1 (31 August 2026)
+## Unreleased
+
+### Monitoring
+
+A Prometheus scrape endpoint is now available (`/metrics`). It is disabled by default; enable it with
+`BUGSINK["PROMETHEUS_ENABLED"] = True`. It uses `django-prometheus`: its middleware records http-request, response and
+template metrics, and its model instrumentation records insert/update/delete counters. Note that no database-query
+metrics are exported: doing so would require swapping Bugsink's custom SQLite backend, which we don't want to do.
 
 ### Backwards incompatible changes
 

--- a/bugsink/app_settings.py
+++ b/bugsink/app_settings.py
@@ -114,6 +114,11 @@ DEFAULTS = {
     "EXTRA_URLCONF_MODULES": [],
     "EXTRA_NAV_LINKS": [],
     "SYSTEM_WARNING_PROVIDERS": [],
+
+    # Monitoring
+    # When enabled, a /metrics endpoint (Prometheus scrape target) is exposed. Off by default, because exposing it
+    # makes operational (request/template/model-activity) metrics readable to anyone who can reach the URL.
+    "PROMETHEUS_ENABLED": True,
 }
 
 

--- a/bugsink/settings/default.py
+++ b/bugsink/settings/default.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'drf_spectacular',
     'drf_spectacular_sidecar',  # this brings the swagger-ui
+    'django_prometheus',
 ]
 
 REST_FRAMEWORK = {
@@ -136,6 +137,8 @@ AUTH_USER_MODEL = "users.User"
 TAILWIND_APP_NAME = 'theme'
 
 MIDDLEWARE = [
+    # django-prometheus: must be the first and last middlewares so that its timing metrics cover the whole request.
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     "bugsink.middleware.ContentEncodingCheckMiddleware",
     'bugsink.middleware.SetRemoteAddrMiddleware',
     'bugsink.middleware.DisallowChunkedMiddleware',
@@ -160,6 +163,7 @@ MIDDLEWARE = [
     # middleware are not logged to a visible location; and this feature is undocumented. However, it _could_ prove
     # useful in such contexts too, so I'm not going to put it behind a conditional.
     'bugsink.middleware.PerformanceStatsMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 # Config of verbose_csrf_middleware.CsrfViewMiddleware: For Bugsink, there's never any intentional cross-scheme POSTing

--- a/bugsink/urls.py
+++ b/bugsink/urls.py
@@ -99,6 +99,12 @@ urlpatterns = [
     path('bsmain/', include('bsmain.urls')),
 ]
 
+# A prometheus scrape endpoint, gated on BUGSINK['PROMETHEUS_ENABLED'] because it exposes operational (request,
+# template, model-activity) metrics to anyone who can reach the URL.
+if get_settings().PROMETHEUS_ENABLED:
+    from .views import metrics
+    urlpatterns.append(path("metrics/", metrics, name="metrics"))
+
 for urlconf_module in get_settings().EXTRA_URLCONF_MODULES:
     urlpatterns.append(path("", include(urlconf_module)))
 

--- a/bugsink/views.py
+++ b/bugsink/views.py
@@ -38,6 +38,8 @@ from ingest.views import BaseIngestAPIView
 from bsmain.models import CachedModelCount
 from bsmain.tasks import count_model
 
+from django_prometheus.exports import ExportToDjangoView
+
 
 AnnotatedCount = namedtuple("AnnotatedCount", ["count", "timestamp"])
 
@@ -293,3 +295,10 @@ def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
     if request.path.startswith("/api/"):
         template_name = "4xx_5xx_api.txt"
     return django_page_not_found(request, _exception_for_error_page(exception), template_name)
+
+
+# Prometheus metrics endpoint
+@login_exempt
+@require_GET
+def metrics(request):
+    return ExportToDjangoView(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pygments==2.20.*
 inotify_simple==2.0.*
 Brotli==1.2.*
 python-dateutil==2.9.*
+django-prometheus==2.*
 whitenoise==6.12.*
 requests==2.34.*
 monofy==1.2.*


### PR DESCRIPTION

A Prometheus scrape endpoint is now available (`/metrics`). It is disabled by default; enable it with `BUGSINK["PROMETHEUS_ENABLED"] = True`. It uses `django-prometheus`: its middleware records HTTP request, response and template metrics, and its model instrumentation records insert/update/delete counters. Note that no database-query metrics are exported: doing so would require swapping Bugsink's custom SQLite backend, which we don't want to do.