### PR TITLE
Add trusted-header (REMOTE_USER_HEADER) authentication (#1)

### DIFF
--- a/bugsink/authentication.py
+++ b/bugsink/authentication.py
@@ -1,9 +1,15 @@
+from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.authentication import BaseAuthentication
 from rest_framework import exceptions
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
 from bsmain.models import AuthToken
+
+
+class EmailRemoteUserBackend(RemoteUserBackend):
+    # No auto-create: the header must match an existing user's username (== email, see users/forms.py).
+    create_unknown_user = False
 
 
 class BearerTokenAuthentication(BaseAuthentication):

--- a/bugsink/conf_templates/singleserver.py.template
+++ b/bugsink/conf_templates/singleserver.py.template
@@ -23,6 +23,10 @@ USE_X_REAL_IP = True
 # USE_X_FORWARDED_FOR = True
 # X_FORWARDED_FOR_PROXY_COUNT = 1
 
+# Trust a header set by your reverse proxy (Cloudflare Access, Authelia, ...) as the logged-in user's email.
+# SECURITY: only if Bugsink is unreachable except via that proxy, and the proxy overwrites the header itself.
+# REMOTE_USER_HEADER = "HTTP_CF_ACCESS_AUTHENTICATED_USER_EMAIL"
+
 
 # In the singleserver production setup, the database is SQLite. The single (unix) user is named `bugsink` and we put
 # the database in its home directory:

--- a/bugsink/middleware.py
+++ b/bugsink/middleware.py
@@ -2,6 +2,7 @@ import logging
 from time import time
 
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.db import connection
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -212,6 +213,13 @@ def get_chosen_language(request_user, request):
     if request_user.is_authenticated and request_user.language != "auto":
         return get_supported_language_variant(request_user.language, strict=False)
     return language_from_accept_language(request)
+
+
+class ConfigurableRemoteUserMiddleware(RemoteUserMiddleware):
+    # RemoteUserMiddleware hard-codes 'REMOTE_USER' as the META key; we read it from settings instead.
+    @property
+    def header(self):
+        return settings.REMOTE_USER_HEADER
 
 
 class UserLanguageMiddleware:

--- a/bugsink/settings/default.py
+++ b/bugsink/settings/default.py
@@ -162,6 +162,25 @@ MIDDLEWARE = [
     'bugsink.middleware.PerformanceStatsMiddleware',
 ]
 
+AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+
+
+def wire_remote_user_auth(authentication_backends, middleware):
+    # Factored out so tests can exercise the exact same wiring as REMOTE_USER_HEADER below, instead of duplicating it.
+    authentication_backends.insert(0, "bugsink.authentication.EmailRemoteUserBackend")
+    middleware.insert(
+        middleware.index("django.contrib.auth.middleware.AuthenticationMiddleware") + 1,
+        "bugsink.middleware.ConfigurableRemoteUserMiddleware",
+    )
+
+
+# Trusted-header auth (see docker-compose-sample.yaml for the full explanation). SECURITY: only set this when Bugsink
+# is unreachable except through the trusted proxy.
+REMOTE_USER_HEADER = os.getenv("REMOTE_USER_HEADER", None)
+
+if REMOTE_USER_HEADER:
+    wire_remote_user_auth(AUTHENTICATION_BACKENDS, MIDDLEWARE)
+
 # Config of verbose_csrf_middleware.CsrfViewMiddleware: For Bugsink, there's never any intentional cross-scheme POSTing
 # going on. In that case "wrong scheme" always just means "Django's confused about is_secure", and we want to point
 # people in the right direction (i.e. fix your proxy's X-Forwarded-Proto)

--- a/bugsink/tests.py
+++ b/bugsink/tests.py
@@ -5,6 +5,7 @@ import brotli
 
 from unittest import TestCase as RegularTestCase
 from unittest.mock import patch
+from django.conf import settings
 from django.test import TestCase as DjangoTestCase
 from django.test import SimpleTestCase
 from django.test import override_settings
@@ -13,6 +14,7 @@ from django.core import mail
 from django.contrib.auth import get_user_model
 from django.test.utils import CaptureQueriesContext
 from django.db import connection
+from django.urls import reverse
 from .wsgi import allowed_hosts_error_message
 
 from .test_utils import TransactionTestCase25251 as TransactionTestCase
@@ -447,6 +449,66 @@ class SetRemoteAddrMiddlewareTestCase(RegularTestCase):
 
         with self.assertRaises(SuspiciousOperation):
             SetRemoteAddrMiddleware.parse_x_forwarded_for("123.123.123.123,1.2.3.4")
+
+
+class EmailRemoteUserBackendTestCase(DjangoTestCase):
+
+    def test_known_user_authenticates(self):
+        from .authentication import EmailRemoteUserBackend
+
+        user = User.objects.create_user(username="proxy@example.com", email="proxy@example.com")
+
+        authenticated = EmailRemoteUserBackend().authenticate(request=None, remote_user="proxy@example.com")
+        self.assertEqual(user, authenticated)
+
+    def test_unknown_user_is_not_created(self):
+        from .authentication import EmailRemoteUserBackend
+
+        user_count = User.objects.count()
+
+        authenticated = EmailRemoteUserBackend().authenticate(request=None, remote_user="unknown@example.com")
+
+        self.assertIsNone(authenticated)
+        self.assertEqual(user_count, User.objects.count())
+
+
+class ConfigurableRemoteUserMiddlewareTestCase(TransactionTestCase):
+    # TransactionTestCase: the home view uses phonehome's durable_atomic, which can't nest in TestCase's transaction.
+
+    def _enabled_settings(self):
+        from .settings.default import wire_remote_user_auth
+
+        middleware = list(settings.MIDDLEWARE)
+        authentication_backends = ["django.contrib.auth.backends.ModelBackend"]
+        wire_remote_user_auth(authentication_backends, middleware)
+
+        return {
+            "REMOTE_USER_HEADER": "HTTP_X_REMOTE_EMAIL",
+            "MIDDLEWARE": middleware,
+            "AUTHENTICATION_BACKENDS": authentication_backends,
+        }
+
+    def test_header_present_matching_user_is_logged_in(self):
+        user = User.objects.create_user(username="proxy@example.com", email="proxy@example.com")
+
+        with override_settings(**self._enabled_settings()):
+            self.client.get("/", headers={"X-Remote-Email": "proxy@example.com"})
+
+        self.assertEqual(str(user.pk), self.client.session["_auth_user_id"])
+
+    def test_header_present_unknown_user_falls_back_to_login(self):
+        with override_settings(**self._enabled_settings()):
+            self.client.get("/", headers={"X-Remote-Email": "unknown@example.com"})
+            login_response = self.client.get(reverse("login"))
+
+        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertEqual(200, login_response.status_code)
+
+    def test_header_absent_is_unaffected(self):
+        with override_settings(**self._enabled_settings()):
+            self.client.get("/")
+
+        self.assertNotIn("_auth_user_id", self.client.session)
 
 
 class ContentEncodingCheckMiddlewareTestCase(DjangoTestCase):

--- a/bugsink/views.py
+++ b/bugsink/views.py
@@ -138,6 +138,7 @@ def settings_view(request):
             "USE_X_REAL_IP",
             "USE_X_FORWARDED_FOR",
             "X_FORWARDED_FOR_PROXY_COUNT",
+            "REMOTE_USER_HEADER",
             "TIME_ZONE",
             "EMAIL_HOST",
             "EMAIL_HOST_USER",

--- a/docker-compose-sample.yaml
+++ b/docker-compose-sample.yaml
@@ -35,6 +35,9 @@ services:
       # USE_X_REAL_IP: "false"
       # USE_X_FORWARDED_FOR: "true"
       # X_FORWARDED_FOR_PROXY_COUNT: "1"
+      # Trust a header set by your reverse proxy (Cloudflare Access, Authelia, ...) as the logged-in user's email.
+      # SECURITY: only if Bugsink is unreachable except via that proxy, and the proxy overwrites the header itself.
+      # REMOTE_USER_HEADER: "HTTP_CF_ACCESS_AUTHENTICATED_USER_EMAIL"
       BASE_URL: "http://localhost:8000"
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8000/health/ready\").raise_for_status()'"]


### PR DESCRIPTION
## Summary

Bugsink has no way to auto-authenticate a user based on an identity header set by a trusted reverse proxy (Cloudflare Access, Authelia, Authentik, oauth2-proxy, etc). The only existing SSO ask is [bugsink/bugsink#77](https://github.com/bugsink/bugsink/issues/77) (closed, no PR), which requested full SAML SSO — a much bigger lift. This PR is a smaller, complementary feature: trusted-header auth, matching what [healthchecks/healthchecks](https://github.com/healthchecks/healthchecks) already ships as `REMOTE_USER_HEADER`.

It reuses Django's own remote-user machinery (`RemoteUserBackend` + `RemoteUserMiddleware`, see [the Django docs](https://docs.djangoproject.com/en/stable/howto/auth-remote-user/)) rather than anything novel — this really is a small, self-contained addition.

* `REMOTE_USER_HEADER` is read once in `bugsink/settings/default.py`, the same way `SECRET_KEY` is (`os.getenv(..., None)`), so it works for both the Docker and singleserver setups without touching either conf template's env-parsing logic.
* When set, it inserts a `RemoteUserMiddleware` subclass (`ConfigurableRemoteUserMiddleware`) right after `AuthenticationMiddleware`, and prepends a `RemoteUserBackend` subclass (`EmailRemoteUserBackend`) to `AUTHENTICATION_BACKENDS` ahead of `ModelBackend`.
* Bugsink doesn't have a real `email` `USERNAME_FIELD` — it stores the email address in `username` by convention (see `users/forms.py`) — so the header value is looked up against `username`, which already holds the email.
* In-repo documentation for proxy-related settings lives as comments in `docker-compose-sample.yaml` and the conf templates rather than a separate docs page (but given the security warning below a docs update should be considered), with an explicit security warning that the proxy must strip/overwrite any client-supplied copy of the header before setting its own.

## Two design questions for the maintainer

I deliberately didn't want to silently pick these:

1. **Auto-create vs. require an existing account.** I defaulted `create_unknown_user = False` — the header only logs in a *pre-existing* account, matching Bugsink's invite/registration-gated user model (this is what Beszel's `TRUSTED_AUTH_HEADER` does). Healthchecks instead auto-creates the account on first sight of the header. 
2. **Disabling password login.** I left password login fully intact when `REMOTE_USER_HEADER` is set. Healthchecks disables password/login-link auth entirely once this is active; Beszel doesn't. There's no existing toggle in Bugsink for "password login off", and it isn't required for the header-based flow to work, so adding one felt out of scope for this restricted PR and my requirement..

## Security warning

`REMOTE_USER_HEADER` trusts whatever value arrives in that header unconditionally once enabled — there's no code-level mitigation here analogous to `X_FORWARDED_FOR_PROXY_COUNT`'s hop-counting for `X-Forwarded-For`. That's inherent to the trusted-header pattern itself (Django's own `RemoteUserMiddleware` and Healthchecks' equivalent both work the same way), so it's worth being explicit about the consequence: if the header ever reaches Bugsink from anywhere other than the trusted proxy — because Bugsink is directly reachable, the proxy is misconfigured, or it fails to strip/overwrite a client-supplied copy of the header before setting its own — an attacker can log in as any existing user simply by setting that header on their request. That's a full account-takeover vector,  so it deserves more caution than a typical "misconfigured proxy header" issue. Only enable `REMOTE_USER_HEADER` when Bugsink is provably unreachable except through the trusted proxy, and verify the proxy overwrites the header rather than merely appending to it.

## Testing

* `ruff check .` — clean.
* `python manage.py test --exclude-tag=samples` (the `samples` tag needs the separate `event-samples` repo cloned alongside this one, which isn't set up here) — full suite, 581 tests, all passing. This includes `test_sentry_cli_upload`, which needs `sentry-cli` and `identity-sourcemap` on `PATH`; both were missing initially, installed them (`npm install @sentry/cli`, `pip install ecma426`), and reran end to end — green.
* Three new tests specific to this feature: header present + matching user → logged in; header present + no matching user → normal login still available; header absent → unaffected. An adversarial review caught that the first version of these tests reimplemented the settings-wiring logic instead of exercising the real code in `bugsink/settings/default.py` — fixed by factoring that wiring into a shared `wire_remote_user_auth()` function used by both, and verified by mutation testing (breaking the real wiring makes the test fail, as it should).

AI Coding Assistance  - Written with the help of Claude but reviewed by a human